### PR TITLE
Fix animals.yaml formatting

### DIFF
--- a/data/animals.yaml
+++ b/data/animals.yaml
@@ -1,56 +1,43 @@
-{
-  "Allosaurus": {
-    "abilities": [
-      "bite": [
-		"damage": 50,
-		"stamina": 40,
-		"effects": [],
-	  ],
-	  "scratch": [
-		"damage": 20,
-		"stamina": 0,
-		"effects": [],
-	  ],
-	  "roar": [
-		"damage": 0,
-		"stamina": 20,
-		"effects": [],
-	  ],
-	  "tail swipe": [
-		"damage": 35,
-		"stamina": 20,
-		"effects": [],
-	  ],
-    ],
-	"health": 210,
-    "image": "assets/animals/allosaurus.png",
-	"speed": 100
-  },
-  "Stegosaurus": {
-    "abilities": [
-      "bite": [
-		"damage": 20,
-		"stamina": 20,
-		"effects": [],
-	  ],
-	  "stomp": [
-		"damage": 15,
-		"stamina": 10,
-		"effects": [],
-	  ],
-	  "roar": [
-		"damage": 0,
-		"stamina": 0,
-		"effects": [],
-	  ],
-	  "thagomizer swipe": [
-		"damage": 55,
-		"stamina": 40,
-		"effects": [],
-	  ],
-    ],
-	"health": 290,
-    "image": "assets/animals/stegosaurus.png",
-	"speed": 60
-  }
-}
+Allosaurus:
+  health: 210
+  speed: 100
+  image: assets/animals/allosaurus.png
+  abilities:
+    - name: bite
+      damage: 50
+      stamina: 40
+      effects: []
+    - name: scratch
+      damage: 20
+      stamina: 0
+      effects: []
+    - name: roar
+      damage: 0
+      stamina: 20
+      effects: []
+    - name: tail swipe
+      damage: 35
+      stamina: 20
+      effects: []
+
+Stegosaurus:
+  health: 290
+  speed: 60
+  image: assets/animals/stegosaurus.png
+  abilities:
+    - name: bite
+      damage: 20
+      stamina: 20
+      effects: []
+    - name: stomp
+      damage: 15
+      stamina: 10
+      effects: []
+    - name: roar
+      damage: 0
+      stamina: 0
+      effects: []
+    - name: thagomizer swipe
+      damage: 55
+      stamina: 40
+      effects: []


### PR DESCRIPTION
## Summary
- fix `animals.yaml` to use valid YAML syntax for `Allosaurus` and `Stegosaurus`

## Testing
- `python3 - <<'EOF'
import yaml
with open('data/animals.yaml') as f:
    print(yaml.safe_load(f))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6870f49ca40c832eb452f932715747bb