### PR TITLE
Fix missing version in PyTorch native dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <dependency>
             <groupId>ai.djl.pytorch</groupId>
             <artifactId>pytorch-native-auto</artifactId>
+            <version>1.9.1</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- specify the version for the `pytorch-native-auto` runtime

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687123a8840c832e9d58243557144294