### PR TITLE
Implement battle engine

### DIFF
--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -1,0 +1,83 @@
+package com.mesozoic.arena.engine;
+
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.Player;
+
+/**
+ * Handles turn management and rule enforcement for a battle between two
+ * players.
+ */
+public class Battle {
+    private final Player playerOne;
+    private final Player playerTwo;
+    private Player winner;
+
+    public Battle(Player playerOne, Player playerTwo) {
+        this.playerOne = playerOne;
+        this.playerTwo = playerTwo;
+    }
+
+    /**
+     * Executes a single round where each player performs the provided move.
+     * The order of execution is determined by the active dinosaurs' speed.
+     */
+    public void executeRound(Move playerOneMove, Move playerTwoMove) {
+        if (winner != null) {
+            return;
+        }
+
+        Dinosaur dinoOne = playerOne.getActiveDinosaur();
+        Dinosaur dinoTwo = playerTwo.getActiveDinosaur();
+        if (dinoOne == null || dinoTwo == null) {
+            return;
+        }
+
+        if (dinoOne.getSpeed() >= dinoTwo.getSpeed()) {
+            performTurn(playerOne, playerTwo, playerOneMove);
+            if (winner == null) {
+                performTurn(playerTwo, playerOne, playerTwoMove);
+            }
+        } else {
+            performTurn(playerTwo, playerOne, playerTwoMove);
+            if (winner == null) {
+                performTurn(playerOne, playerTwo, playerOneMove);
+            }
+        }
+    }
+
+    /**
+     * Returns the winning player once the battle has concluded or {@code null}
+     * if it is still ongoing.
+     */
+    public Player getWinner() {
+        return winner;
+    }
+
+    private void performTurn(Player actingPlayer, Player opposingPlayer, Move move) {
+        Dinosaur attacker = actingPlayer.getActiveDinosaur();
+        Dinosaur defender = opposingPlayer.getActiveDinosaur();
+        if (attacker == null || defender == null || move == null) {
+            return;
+        }
+
+        // regenerate stamina at the start of the turn
+        attacker.adjustStamina(10);
+
+        // apply move effects
+        attacker.adjustStamina(-move.getStaminaCost());
+        defender.adjustHealth(-move.getDamage());
+
+        checkFaint(opposingPlayer);
+    }
+
+    private void checkFaint(Player player) {
+        Dinosaur active = player.getActiveDinosaur();
+        if (active != null && active.getHealth() <= 0) {
+            player.removeDinosaur(active);
+            if (!player.hasRemainingDinosaurs()) {
+                winner = (player == playerOne) ? playerTwo : playerOne;
+            }
+        }
+    }
+}

--- a/src/main/java/com/mesozoic/arena/model/Player.java
+++ b/src/main/java/com/mesozoic/arena/model/Player.java
@@ -34,4 +34,35 @@ public class Player {
             this.activeDinosaur = dinosaur;
         }
     }
+
+    /**
+     * Removes the given dinosaur from the player's roster. If the removed
+     * dinosaur was active, the next available dinosaur becomes active.
+     */
+    public void removeDinosaur(Dinosaur dinosaur) {
+        dinosaurs.remove(dinosaur);
+        if (dinosaur.equals(activeDinosaur)) {
+            activateNextDinosaur();
+        }
+    }
+
+    /**
+     * Sets the next dinosaur in the roster as active. Returns the new active
+     * dinosaur or {@code null} if none remain.
+     */
+    public Dinosaur activateNextDinosaur() {
+        if (dinosaurs.isEmpty()) {
+            activeDinosaur = null;
+        } else {
+            activeDinosaur = dinosaurs.get(0);
+        }
+        return activeDinosaur;
+    }
+
+    /**
+     * Indicates whether the player still has dinosaurs remaining.
+     */
+    public boolean hasRemainingDinosaurs() {
+        return !dinosaurs.isEmpty();
+    }
 }


### PR DESCRIPTION
## Summary
- flesh out player roster management with helpers for removing, activating, and checking dinosaurs
- add `Battle` class to manage turns, stamina, and fainted dinosaurs

## Testing
- `mvn -e -DskipTests compile`
- `mvn -e test`


------
https://chatgpt.com/codex/tasks/task_e_68712bde6a8c832e9dee35db7658a3de