### PR TITLE
Add RandomOpponent AI and integrate automatic enemy turns

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/RandomOpponent.java
+++ b/src/main/java/com/mesozoic/arena/ai/RandomOpponent.java
@@ -1,0 +1,36 @@
+package com.mesozoic.arena.ai;
+
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Move;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Simple AI that selects a random move the dinosaur has enough stamina to use.
+ */
+public class RandomOpponent {
+    private final Random random = new Random();
+
+    /**
+     * Chooses a move for the given dinosaur based on current stamina.
+     *
+     * @param self the acting dinosaur
+     * @return a usable move or {@code null} if none can be performed
+     */
+    public Move chooseMove(Dinosaur self) {
+        if (self == null) {
+            return null;
+        }
+        List<Move> usable = new ArrayList<>();
+        for (Move move : self.getMoves()) {
+            if (self.getStamina() >= move.getStaminaCost()) {
+                usable.add(move);
+            }
+        }
+        if (usable.isEmpty()) {
+            return null;
+        }
+        return usable.get(random.nextInt(usable.size()));
+    }
+}

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -1,5 +1,6 @@
 package com.mesozoic.arena.engine;
 
+import com.mesozoic.arena.ai.RandomOpponent;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Player;
@@ -11,11 +12,17 @@ import com.mesozoic.arena.model.Player;
 public class Battle {
     private final Player playerOne;
     private final Player playerTwo;
+    private final RandomOpponent opponentAI;
     private Player winner;
 
     public Battle(Player playerOne, Player playerTwo) {
+        this(playerOne, playerTwo, new RandomOpponent());
+    }
+
+    public Battle(Player playerOne, Player playerTwo, RandomOpponent opponentAI) {
         this.playerOne = playerOne;
         this.playerTwo = playerTwo;
+        this.opponentAI = opponentAI;
     }
 
     /**
@@ -44,6 +51,14 @@ public class Battle {
                 performTurn(playerOne, playerTwo, playerOneMove);
             }
         }
+    }
+
+    /**
+     * Executes a round using the AI to select the opponent's move.
+     */
+    public void executeRound(Move playerOneMove) {
+        Move playerTwoMove = opponentAI.chooseMove(playerTwo.getActiveDinosaur());
+        executeRound(playerOneMove, playerTwoMove);
     }
 
     /**

--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -7,11 +7,9 @@ import com.mesozoic.arena.model.Player;
 import java.awt.BorderLayout;
 import java.awt.GridLayout;
 import java.awt.Image;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JFrame;
@@ -42,7 +40,6 @@ public class MainWindow extends JFrame {
     private JLabel opponentSpeedLabel;
     private JLabel opponentImageLabel;
 
-    private final Random random = new Random();
 
     public MainWindow(Battle battle, Player player, Player opponent) {
         this.battle = battle;
@@ -200,13 +197,7 @@ public class MainWindow extends JFrame {
     }
 
     private void handlePlayerMove(Move playerMove) {
-        Dinosaur opponentDino = opponent.getActiveDinosaur();
-        Move opponentMove = null;
-        if (opponentDino != null && !opponentDino.getMoves().isEmpty()) {
-            List<Move> moves = opponentDino.getMoves();
-            opponentMove = moves.get(random.nextInt(moves.size()));
-        }
-        battle.executeRound(playerMove, opponentMove);
+        battle.executeRound(playerMove);
         refreshDisplay();
         checkWinner();
     }


### PR DESCRIPTION
## Summary
- add `RandomOpponent` that picks a random usable move
- update `Battle` to use the AI for the second player
- simplify `MainWindow` by letting `Battle` decide the opponent's move

## Testing
- `mvn -DskipTests=false test`
- `mvn -DskipTests=true package`


------
https://chatgpt.com/codex/tasks/task_e_687135bb9f40832ebc68c33e37aeeff2