### PR TITLE
Add configurable LLM opponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Mesozoic Arena
+
+## LLM Opponent
+
+The project can use a small language model to drive the opponent AI. The weights
+are not bundled with the repository. To enable the LLM based agent:
+
+1. Download the `distilgpt2` model from Hugging Face and extract it to
+   `models/gpt2` so that the directory contains `config.json`, `pytorch_model.bin`
+   and related files.
+2. Edit `data/constants.ini` and set `useLLMAgent=true`.
+
+If the model cannot be loaded, the game falls back to a random strategy.

--- a/data/constants.ini
+++ b/data/constants.ini
@@ -1,1 +1,2 @@
 [DEFAULT]
+useLLMAgent=false

--- a/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
@@ -1,0 +1,66 @@
+package com.mesozoic.arena.ai;
+
+import ai.djl.ModelException;
+import ai.djl.modality.nlp.translator.SimpleText2TextTranslator;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.repository.zoo.ZooModel;
+import ai.djl.translate.TranslateException;
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Move;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Opponent powered by a local language model.
+ */
+public class LLMAgent implements OpponentAgent {
+    private final ZooModel<String, String> model;
+
+    /**
+     * Loads the model from the local {@code models} directory.
+     */
+    public LLMAgent() throws IOException, ModelException {
+        var translator = new SimpleText2TextTranslator();
+        Criteria<String, String> criteria = Criteria.builder()
+                .setTypes(String.class, String.class)
+                .optModelPath(Paths.get("models/gpt2"))
+                .optTranslator(translator)
+                .build();
+        model = criteria.loadModel();
+    }
+
+    @Override
+    public Move chooseMove(Dinosaur self, Dinosaur enemy) {
+        if (self == null || enemy == null) {
+            return null;
+        }
+        String prompt = buildPrompt(self, enemy);
+        try (var predictor = model.newPredictor()) {
+            String output = predictor.predict(prompt);
+            return parseMove(output, self);
+        } catch (TranslateException e) {
+            return new RandomOpponent().chooseMove(self, enemy);
+        }
+    }
+
+    private Move parseMove(String output, Dinosaur self) {
+        for (Move move : self.getMoves()) {
+            if (output.toLowerCase().contains(move.getName().toLowerCase())
+                    && self.getStamina() >= move.getStaminaCost()) {
+                return move;
+            }
+        }
+        return new RandomOpponent().chooseMove(self, null);
+    }
+
+    private String buildPrompt(Dinosaur self, Dinosaur enemy) {
+        List<String> moveNames = self.getMoves().stream()
+                .map(Move::getName)
+                .collect(Collectors.toList());
+        return "Choose the best move for " + self.getName()
+                + " against " + enemy.getName() + ". Available moves: "
+                + String.join(", ", moveNames) + ".";
+    }
+}

--- a/src/main/java/com/mesozoic/arena/ai/OpponentAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/OpponentAgent.java
@@ -1,0 +1,18 @@
+package com.mesozoic.arena.ai;
+
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Move;
+
+/**
+ * Strategy interface for selecting a move in battle.
+ */
+public interface OpponentAgent {
+    /**
+     * Chooses a move for the acting dinosaur.
+     *
+     * @param self the acting dinosaur
+     * @param enemy the opposing dinosaur
+     * @return the selected move or {@code null} if none can be performed
+     */
+    Move chooseMove(Dinosaur self, Dinosaur enemy);
+}

--- a/src/main/java/com/mesozoic/arena/ai/RandomOpponent.java
+++ b/src/main/java/com/mesozoic/arena/ai/RandomOpponent.java
@@ -9,28 +9,28 @@ import java.util.Random;
 /**
  * Simple AI that selects a random move the dinosaur has enough stamina to use.
  */
-public class RandomOpponent {
+public class RandomOpponent implements OpponentAgent {
     private final Random random = new Random();
 
-    /**
-     * Chooses a move for the given dinosaur based on current stamina.
-     *
-     * @param self the acting dinosaur
-     * @return a usable move or {@code null} if none can be performed
-     */
-    public Move chooseMove(Dinosaur self) {
+    @Override
+    public Move chooseMove(Dinosaur self, Dinosaur enemy) {
         if (self == null) {
             return null;
         }
-        List<Move> usable = new ArrayList<>();
-        for (Move move : self.getMoves()) {
-            if (self.getStamina() >= move.getStaminaCost()) {
-                usable.add(move);
-            }
-        }
+        List<Move> usable = getUsableMoves(self);
         if (usable.isEmpty()) {
             return null;
         }
         return usable.get(random.nextInt(usable.size()));
+    }
+
+    private List<Move> getUsableMoves(Dinosaur dinosaur) {
+        List<Move> usable = new ArrayList<>();
+        for (Move move : dinosaur.getMoves()) {
+            if (dinosaur.getStamina() >= move.getStaminaCost()) {
+                usable.add(move);
+            }
+        }
+        return usable;
     }
 }

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -1,6 +1,9 @@
 package com.mesozoic.arena.engine;
 
+import com.mesozoic.arena.ai.LLMAgent;
+import com.mesozoic.arena.ai.OpponentAgent;
 import com.mesozoic.arena.ai.RandomOpponent;
+import com.mesozoic.arena.util.Config;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Player;
@@ -12,17 +15,28 @@ import com.mesozoic.arena.model.Player;
 public class Battle {
     private final Player playerOne;
     private final Player playerTwo;
-    private final RandomOpponent opponentAI;
+    private final OpponentAgent opponentAI;
     private Player winner;
 
     public Battle(Player playerOne, Player playerTwo) {
-        this(playerOne, playerTwo, new RandomOpponent());
+        this(playerOne, playerTwo, createAgent());
     }
 
-    public Battle(Player playerOne, Player playerTwo, RandomOpponent opponentAI) {
+    public Battle(Player playerOne, Player playerTwo, OpponentAgent opponentAI) {
         this.playerOne = playerOne;
         this.playerTwo = playerTwo;
         this.opponentAI = opponentAI;
+    }
+
+    private static OpponentAgent createAgent() {
+        if (Config.useLLMAgent()) {
+            try {
+                return new LLMAgent();
+            } catch (Exception e) {
+                System.err.println("Failed to load LLM model, falling back to random opponent");
+            }
+        }
+        return new RandomOpponent();
     }
 
     /**
@@ -57,7 +71,8 @@ public class Battle {
      * Executes a round using the AI to select the opponent's move.
      */
     public void executeRound(Move playerOneMove) {
-        Move playerTwoMove = opponentAI.chooseMove(playerTwo.getActiveDinosaur());
+        Move playerTwoMove = opponentAI.chooseMove(playerTwo.getActiveDinosaur(),
+                playerOne.getActiveDinosaur());
         executeRound(playerOneMove, playerTwoMove);
     }
 

--- a/src/main/java/com/mesozoic/arena/util/Config.java
+++ b/src/main/java/com/mesozoic/arena/util/Config.java
@@ -1,0 +1,33 @@
+package com.mesozoic.arena.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Loads configuration from {@code constants.ini}.
+ */
+public final class Config {
+    private static final String CONFIG_FILE = "constants.ini";
+    private static final Properties properties = new Properties();
+
+    static {
+        try (InputStream in = Config.class.getClassLoader()
+                .getResourceAsStream(CONFIG_FILE)) {
+            if (in != null) {
+                properties.load(in);
+            }
+        } catch (IOException ignored) {
+        }
+    }
+
+    private Config() {
+    }
+
+    /**
+     * Indicates whether the application should use the LLM for the opponent.
+     */
+    public static boolean useLLMAgent() {
+        return Boolean.parseBoolean(properties.getProperty("useLLMAgent", "false"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `OpponentAgent` interface
- create `LLMAgent` using DJL to load a model
- update `RandomOpponent` to implement the new interface
- add configuration loader and hook it up in `Battle`
- document how to download the language model

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68713714ebf4832ea13ac70ee65af003