### PR TITLE
Update LLM instructions for Mistral 7B

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,24 @@ close the window. The match ends when one side has no dinosaurs remaining.
 
 ## LLM Opponent
 
-The project can use a small language model to drive the opponent AI. The weights
-are not bundled with the repository. To enable the LLM based agent:
+The project can use a language model to drive the opponent AI. Mistral&nbsp;7B
+Instruct provides much stronger responses than the originally suggested GPT-2
+model. The weights are not bundled with the repository. To enable the LLM based
+agent:
 
-1. Download the `distilgpt2` model from Hugging Face and extract it to
-   `models/gpt2` so that the directory contains `config.json`,
+1. Download the `Mistral-7B-Instruct-v0.2` model from Hugging Face and extract
+   it to `models/mistral` so that the directory contains `config.json`,
    `pytorch_model.bin` and the related files. A quick option is:
 
    ```bash
-   huggingface-cli download distilgpt2 --local-dir models/gpt2
+   huggingface-cli download mistralai/Mistral-7B-Instruct-v0.2 \
+       --local-dir models/mistral
    ```
 
-   or download the archive from the web interface and extract it manually.
+   or download the archive from the web interface and extract it manually. The
+   full model requires more than 12&nbsp;GB of GPU memory; if your card does not
+   have enough VRAM you may need to run on the CPU or use a quantized
+   checkpoint.
 2. Edit `data/constants.ini` and set `useLLMAgent=true`.
 
 If the model cannot be loaded, the game falls back to a random strategy.

--- a/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
@@ -25,7 +25,7 @@ public class LLMAgent implements OpponentAgent {
         var translator = new SimpleText2TextTranslator();
         Criteria<String, String> criteria = Criteria.builder()
                 .setTypes(String.class, String.class)
-                .optModelPath(Paths.get("models/gpt2"))
+                .optModelPath(Paths.get("models/mistral"))
                 .optTranslator(translator)
                 .build();
         model = criteria.loadModel();


### PR DESCRIPTION
## Summary
- use the Mistral 7B Instruct model for the AI opponent
- document the larger model and GPU memory needs

## Testing
- `mvn -q -DskipTests package`

------
https://chatgpt.com/codex/tasks/task_e_68713f2f9254832e984ae29ee94a224d