### PR TITLE
Enable simpler game launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Start the game through Maven so that all dependencies are automatically added to
 the class path:
 
 ```bash
-mvn exec:java -Dexec.mainClass=com.mesozoic.arena.App -Dexec.classpathScope=runtime
+mvn exec:java
 ```
 
 ## Gameplay

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,15 @@
                     <release>17</release>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.mesozoic.arena.App</mainClass>
+                    <classpathScope>runtime</classpathScope>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <resource>


### PR DESCRIPTION
## Summary
- configure exec-maven-plugin with the game's main class
- update README to use the simpler `mvn exec:java` command

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_6871596d580c832e9887df289ada24d9