### PR TITLE
Update switch mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ mvn exec:java -Dexec.mainClass=com.mesozoic.arena.App -Dexec.classpathScope=runt
 When launched, a window displays your active dinosaur on the left and the
 opponent on the right. Four buttons at the bottom correspond to the moves of the
 currently active dinosaur. Additional dinosaurs appear in the bench area with a
-`Switch` button that swaps them into battle. Use the **Exit Game** button to
-close the window. The match ends when one side has no dinosaurs remaining.
+`Switch` button. Selecting it consumes your turn but the swap happens before any
+attacks are performed, so incoming damage hits the new dinosaur. Use the
+**Exit Game** button to close the window. The match ends when one side has no
+dinosaurs remaining.
 
 ## LLM Opponent
 

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -65,6 +65,13 @@ public class Battle {
             return;
         }
 
+        if (applyQueuedSwitch(playerOne, "Player")) {
+            playerOneMove = null;
+        }
+        if (applyQueuedSwitch(playerTwo, "Opponent")) {
+            playerTwoMove = null;
+        }
+
         Dinosaur dinoOne = playerOne.getActiveDinosaur();
         Dinosaur dinoTwo = playerTwo.getActiveDinosaur();
         if (dinoOne == null || dinoTwo == null) {
@@ -131,5 +138,16 @@ public class Battle {
                 winner = (player == playerOne) ? playerTwo : playerOne;
             }
         }
+    }
+
+    private boolean applyQueuedSwitch(Player player, String label) {
+        Dinosaur target = player.getQueuedSwitch();
+        if (target == null) {
+            return false;
+        }
+        player.setActiveDinosaur(target);
+        player.clearQueuedSwitch();
+        eventLog.add(label + " switched to " + target.getName() + ".");
+        return true;
     }
 }

--- a/src/main/java/com/mesozoic/arena/model/Player.java
+++ b/src/main/java/com/mesozoic/arena/model/Player.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class Player {
     private final List<Dinosaur> dinosaurs;
     private Dinosaur activeDinosaur;
+    private Dinosaur queuedSwitch;
 
     public Player(List<Dinosaur> dinosaurs) {
         if (dinosaurs == null) {
@@ -33,6 +34,29 @@ public class Player {
         if (dinosaurs.contains(dinosaur)) {
             this.activeDinosaur = dinosaur;
         }
+    }
+
+    /**
+     * Queues a switch to the specified dinosaur for the next turn.
+     */
+    public void queueSwitch(Dinosaur dinosaur) {
+        if (dinosaurs.contains(dinosaur) && !dinosaur.equals(activeDinosaur)) {
+            queuedSwitch = dinosaur;
+        }
+    }
+
+    /**
+     * Returns the dinosaur selected for switching or {@code null} if none.
+     */
+    public Dinosaur getQueuedSwitch() {
+        return queuedSwitch;
+    }
+
+    /**
+     * Clears any queued switch action.
+     */
+    public void clearQueuedSwitch() {
+        queuedSwitch = null;
     }
 
     /**

--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -182,8 +182,8 @@ public class MainWindow extends JFrame {
             p.add(new JLabel(dino.getName()));
             JButton switchButton = new JButton("Switch");
             switchButton.addActionListener(e -> {
-                player.setActiveDinosaur(dino);
-                refreshDisplay();
+                player.queueSwitch(dino);
+                handlePlayerMove(null);
             });
             p.add(switchButton);
             benchPanel.add(p);


### PR DESCRIPTION
## Summary
- switching now queues for the next turn
- battle engine resolves queued switches before attacks
- update UI to use queued switching
- document new mechanic

## Testing
- `mvn -q -DskipTests package`
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_687159e71a10832e9e7b45711326945a