### PR TITLE
Improve LLM loading logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ agent:
    full model requires more than 12&nbsp;GB of GPU memory; if your card does not
    have enough VRAM you may need to run on the CPU or use a quantized
    checkpoint.
-2. Edit `data/constants.ini` and set `useLLMAgent=true`.
+2. Edit `data/constants.ini` and set `useLLMAgent=true` and
+   `llmModelDir=models/mistral` (or the directory containing the model files).
 
 If the model cannot be loaded, the game falls back to a random strategy.

--- a/data/constants.ini
+++ b/data/constants.ini
@@ -1,2 +1,3 @@
 [DEFAULT]
 useLLMAgent=false
+llmModelDir=models/gpt2

--- a/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
@@ -7,6 +7,7 @@ import ai.djl.repository.zoo.ZooModel;
 import ai.djl.translate.TranslateException;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.util.Config;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
@@ -16,19 +17,28 @@ import java.util.stream.Collectors;
  * Opponent powered by a local language model.
  */
 public class LLMAgent implements OpponentAgent {
+    private static final String MODEL_DIR = Config.llmModelDir();
     private final ZooModel<String, String> model;
 
     /**
      * Loads the model from the local {@code models} directory.
      */
     public LLMAgent() throws IOException, ModelException {
+        model = loadModel();
+    }
+
+    private static ZooModel<String, String> loadModel()
+            throws IOException, ModelException {
+        System.out.println("Loading LLM model from " + MODEL_DIR);
         var translator = new SimpleText2TextTranslator();
         Criteria<String, String> criteria = Criteria.builder()
                 .setTypes(String.class, String.class)
-                .optModelPath(Paths.get("models/gpt2"))
+                .optModelPath(Paths.get(MODEL_DIR))
                 .optTranslator(translator)
                 .build();
-        model = criteria.loadModel();
+        ZooModel<String, String> loadedModel = criteria.loadModel();
+        System.out.println("LLM model loaded successfully");
+        return loadedModel;
     }
 
     @Override

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -50,7 +50,9 @@ public class Battle {
             try {
                 return new LLMAgent();
             } catch (Exception e) {
-                System.err.println("Failed to load LLM model, falling back to random opponent");
+                System.err.println("Failed to load LLM model: " + e.getMessage());
+                e.printStackTrace();
+                System.err.println("Falling back to random opponent");
             }
         }
         return new RandomOpponent();

--- a/src/main/java/com/mesozoic/arena/util/Config.java
+++ b/src/main/java/com/mesozoic/arena/util/Config.java
@@ -30,4 +30,11 @@ public final class Config {
     public static boolean useLLMAgent() {
         return Boolean.parseBoolean(properties.getProperty("useLLMAgent", "false"));
     }
+
+    /**
+     * Returns the directory that contains the language model.
+     */
+    public static String llmModelDir() {
+        return properties.getProperty("llmModelDir", "models/gpt2");
+    }
 }


### PR DESCRIPTION
## Summary
- add detailed logs when loading the LLM model
- print exception details if the model fails to load
- load model directory from `constants.ini`

## Testing
- `mvn -e test`


------
https://chatgpt.com/codex/tasks/task_e_68715c51a72c832ebcbac4ddb23c344e