### PR TITLE
Add LLM output to UI log

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ agent:
    `llmModelDir=models/mistral` (or the directory containing the model files).
 
 If the model cannot be loaded, the game falls back to a random strategy.
+When the LLM agent responds, its raw output is appended to the in-game log
+displayed in the right-hand text box.

--- a/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 public class LLMAgent implements OpponentAgent, AutoCloseable {
 
     private final LlamaModel model;
+    private String lastResponse;
 
     public LLMAgent() {
         String modelPath = Config.llmModelDir() + "/Ministral-3b-instruct.Q4_K_M.gguf";
@@ -43,9 +44,11 @@ public class LLMAgent implements OpponentAgent, AutoCloseable {
                 sb.append(out);
             }
             String output = sb.toString();
+            lastResponse = output;
             return parseMove(output, self);
         } catch (Exception e) {
             e.printStackTrace();
+            lastResponse = "";
             return new RandomOpponent().chooseMove(self, enemy);
         }
     }
@@ -68,6 +71,10 @@ public class LLMAgent implements OpponentAgent, AutoCloseable {
         return "Choose the best move for " + self.getName() +
                 " against " + enemy.getName() + ". Available moves: " +
                 moveList + ".\nMove:";
+    }
+
+    public String getLastResponse() {
+        return lastResponse;
     }
 
     @Override

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -99,6 +99,7 @@ public class Battle {
     public void executeRound(Move playerOneMove) {
         Move playerTwoMove = opponentAI.chooseMove(playerTwo.getActiveDinosaur(),
                 playerOne.getActiveDinosaur());
+        logLLMResponse();
         executeRound(playerOneMove, playerTwoMove);
     }
 
@@ -138,6 +139,15 @@ public class Battle {
             player.removeDinosaur(active);
             if (!player.hasRemainingDinosaurs()) {
                 winner = (player == playerOne) ? playerTwo : playerOne;
+            }
+        }
+    }
+
+    private void logLLMResponse() {
+        if (opponentAI instanceof LLMAgent llm) {
+            String response = llm.getLastResponse();
+            if (response != null && !response.isBlank()) {
+                eventLog.add("LLM: " + response);
             }
         }
     }


### PR DESCRIPTION
## Summary
- store the last response from the LLM opponent
- display the response in the battle log
- document the new behaviour in the README

## Testing
- `mvn -DskipTests package`

------
https://chatgpt.com/codex/tasks/task_e_687189cc7cf8832e8f938a519d280f10