### PR TITLE
Fix Gemini config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The opponent AI can use Google's Gemini Flash model. To enable it:
    `API_KEY=`.
 2. Ensure `useLLMAgent=true` in `data/constants.ini`.
 
+The application first looks for `gemini.env` on the class path but also falls back to the current working directory. Place the file next to the JAR when running a packaged build.
+
 If the API request fails, the game falls back to a random strategy. The raw
 response from the model is appended to the in-game log displayed on the right
 side of the window.

--- a/src/main/java/com/mesozoic/arena/util/Config.java
+++ b/src/main/java/com/mesozoic/arena/util/Config.java
@@ -2,6 +2,8 @@ package com.mesozoic.arena.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
 
 /**
@@ -14,19 +16,22 @@ public final class Config {
     private static final Properties secrets = new Properties();
 
     static {
+        loadProperties(CONFIG_FILE, properties);
+        loadProperties(GEMINI_ENV_FILE, secrets);
+    }
+
+    private static void loadProperties(String fileName, Properties target) {
         try (InputStream in = Config.class.getClassLoader()
-                .getResourceAsStream(CONFIG_FILE)) {
+                .getResourceAsStream(fileName)) {
             if (in != null) {
-                properties.load(in);
+                target.load(in);
+                return;
             }
         } catch (IOException ignored) {
         }
 
-        try (InputStream in = Config.class.getClassLoader()
-                .getResourceAsStream(GEMINI_ENV_FILE)) {
-            if (in != null) {
-                secrets.load(in);
-            }
+        try (InputStream in = Files.newInputStream(Path.of(fileName))) {
+            target.load(in);
         } catch (IOException ignored) {
         }
     }


### PR DESCRIPTION
## Summary
- support reading gemini.env from the working directory
- document gemini.env location in README

## Testing
- `mvn package -DskipTests`

------
https://chatgpt.com/codex/tasks/task_e_68738935e8a8832eae0e4e7305e959cc