### PR TITLE
Move config to YAML and update damage handling

### DIFF
--- a/data/animals.yaml
+++ b/data/animals.yaml
@@ -1,77 +1,32 @@
 Allosaurus:
   health: 210
   speed: 100
+  attack: 10
   image: assets/animals/allosaurus.png
-  abilities:
-    - name: bite
-      damage: 50
-      stamina: -40
-      priority: 0
-      effects: []
-    - name: scratch
-      damage: -20
-      stamina: 0
-      priority: 0
-      effects: []
-    - name: roar
-      damage: 0
-      stamina: -20
-      priority: 0
-      effects: []
-    - name: tail swipe
-      damage: 35
-      stamina: -20
-      priority: 0
-      effects: []
+  moves:
+    - bite
+    - scratch
+    - roar
+    - tail swipe
 
 Ceratosaurus:
   health: 210
   speed: 130
+  attack: 10
   image: assets/animals/ceratosaurus.png
-  abilities:
-    - name: bite
-      damage: 50
-      stamina: -40
-      priority: 0
-      effects: []
-    - name: scratch
-      damage: 20
-      stamina: 0
-      priority: 0
-      effects: []
-    - name: roar
-      damage: 0
-      stamina: -20
-      priority: 0
-      effects: []
-    - name: tail swipe
-      damage: 35
-      stamina: -20
-      priority: 0
-      effects: []
+  moves:
+    - bite
+    - scratch
+    - roar
+    - tail swipe
 
 Stegosaurus:
   health: 290
   speed: 60
+  attack: 10
   image: assets/animals/stegosaurus.png
-  abilities:
-    - name: brace
-      damage: 0
-      stamina: -10
-      priority: 1
-      effects: [brace]
-    - name: stomp
-      damage: 15
-      stamina: 0
-      priority: 0
-      effects: []
-    - name: roar
-      damage: 0
-      stamina: 20
-      priority: 0
-      effects: []
-    - name: thagomizer swipe
-      damage: 55
-      stamina: -30
-      priority: 0
-      effects: []
+  moves:
+    - brace
+    - stomp
+    - roar
+    - thagomizer swipe

--- a/data/moves.yaml
+++ b/data/moves.yaml
@@ -1,0 +1,41 @@
+bite:
+  damage: 5
+  stamina: -40
+  priority: 0
+  effects: []
+
+scratch:
+  damage: 2
+  stamina: 0
+  priority: 0
+  effects: []
+
+roar:
+  damage: 0
+  stamina: -20
+  priority: 0
+  effects: []
+
+tail swipe:
+  damage: 3
+  stamina: -20
+  priority: 0
+  effects: []
+
+brace:
+  damage: 0
+  stamina: -10
+  priority: 1
+  effects: [brace]
+
+stomp:
+  damage: 1
+  stamina: 0
+  priority: 0
+  effects: []
+
+thagomizer swipe:
+  damage: 5
+  stamina: -30
+  priority: 0
+  effects: []

--- a/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
@@ -168,30 +168,35 @@ public class LLMAgent implements OpponentAgent, AutoCloseable {
                 .collect(Collectors.joining(", "));
     }
 
+    private String describeDinosaur(Dinosaur dino) {
+        return dino.getName() + " (HP: " + dino.getHealth() + ", Sta: "
+                + dino.getStamina() + ", Spd: " + dino.getSpeed() + ", Atk: "
+                + dino.getAttack() + ") Moves: " + formatMoves(dino);
+    }
+
     private String buildPrompt(Player selfPlayer, Player enemyPlayer) {
         Dinosaur self = selfPlayer.getActiveDinosaur();
         Dinosaur enemy = enemyPlayer.getActiveDinosaur();
-        String selfMoves = formatMoves(self);
-        String enemyMoves = formatMoves(enemy);
 
-        String bench = selfPlayer.getDinosaurs().stream()
-                .filter(d -> !d.equals(self))
-                .map(Dinosaur::getName)
-                .collect(Collectors.joining(", "));
+        StringBuilder allInfo = new StringBuilder();
+        allInfo.append("Dinosaurs this battle:\n");
+        for (Dinosaur d : selfPlayer.getDinosaurs()) {
+            allInfo.append("Your - ").append(describeDinosaur(d)).append("\n");
+        }
+        for (Dinosaur d : enemyPlayer.getDinosaurs()) {
+            allInfo.append("Opponent - ").append(describeDinosaur(d)).append("\n");
+        }
 
         return "You are playing Mesozoic Arena, a turn based dinosaur battle. " +
                 "The dinosaur with more speed goes first. A dinosaur using a higher priority move goes before " +
                 "dinosaurs using lower priority moves regardless of speed. " +
-                "Using a move changes your dinosaur's available stamina and deals damage equal to that move. " +
-                "You may also switch dinosaurs, which happens before attacks but " +
-                "skips using a move.\n" +
-                "Your dinosaur: " + self.getName() + " (HP: " + self.getHealth() +
-                ", Stamina: " + self.getStamina() + ", Speed: " + self.getSpeed() + ")\n" +
-                "Opponent dinosaur: " + enemy.getName() + " (HP: " + enemy.getHealth() +
-                ", Stamina: " + enemy.getStamina() + ", Speed: " + enemy.getSpeed() + ")\n" +
-                "Your moves (sta refers to stamina change when using the move, which can be positive or negative): " + selfMoves + "\n" +
-                "Opponent moves: " + enemyMoves + "\n" +
-                "You can also switch to: " + bench + ".\n" +
+                "Damage is calculated as your dinosaur's attack multiplied by the move damage. " +
+                "You may also switch dinosaurs, which happens before attacks but skips using a move.\n" +
+                allInfo +
+                "Your active dinosaur: " + self.getName() + " (HP: " + self.getHealth() +
+                ", Sta: " + self.getStamina() + ")\n" +
+                "Opponent active dinosaur: " + enemy.getName() + " (HP: " + enemy.getHealth() +
+                ", Sta: " + enemy.getStamina() + ")\n" +
                 "Respond with the move name to attack or 'Switch to <name>' to switch. " +
                 "End your response with 'Answer: <move>' or 'Answer: Switch to <name>'.\nAction:";
     }

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -138,8 +138,9 @@ public class Battle {
         // apply move effects
         attacker.adjustStamina(move.getStaminaChange());
         if (!defenderBraced) {
+            int totalDamage = move.getDamage() * attacker.getAttack();
             int before = defender.getHealth();
-            defender.adjustHealth(-move.getDamage());
+            defender.adjustHealth(-totalDamage);
             int damage = before - defender.getHealth();
             eventLog.add(attacker.getName() + " used " + move.getName() + " dealing "
                     + damage + " damage. " + defender.getName() + " has "

--- a/src/main/java/com/mesozoic/arena/model/Dinosaur.java
+++ b/src/main/java/com/mesozoic/arena/model/Dinosaur.java
@@ -11,14 +11,17 @@ public class Dinosaur {
     private int health;
     private final int speed;
     private final String imagePath;
+    private final int attack;
     private int stamina;
     private final List<Move> moves;
 
-    public Dinosaur(String name, int health, int speed, String imagePath, int stamina, List<Move> moves) {
+    public Dinosaur(String name, int health, int speed, String imagePath, int stamina, int attack,
+            List<Move> moves) {
         this.name = name;
         this.health = health;
         this.speed = speed;
         this.imagePath = imagePath;
+        this.attack = attack;
         this.stamina = stamina;
         if (moves == null) {
             this.moves = new ArrayList<>();
@@ -41,6 +44,10 @@ public class Dinosaur {
 
     public String getImagePath() {
         return imagePath;
+    }
+
+    public int getAttack() {
+        return attack;
     }
 
     public int getStamina() {


### PR DESCRIPTION
## Summary
- add new `moves.yaml` data file for shared move definitions
- update `animals.yaml` to reference moves and include attack stat
- extend `Dinosaur` model with attack field
- load moves and attack values in `DinosaurLoader`
- multiply move damage by attacker attack in battle logic
- enhance LLM prompt with full dinosaur and move info

## Testing
- `mvn -DskipTests=true clean package`

------
https://chatgpt.com/codex/tasks/task_e_6873d734c3cc832e84e57de6eb209a5a