### PR TITLE
Fix stamina checks for move usage

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
@@ -124,8 +124,7 @@ public class LLMAgent implements OpponentAgent, AutoCloseable {
             return null;
         }
         for (Move move : active.getMoves()) {
-            if (move.getName().equalsIgnoreCase(name) &&
-                    active.getStamina() >= move.getStaminaChange()) {
+            if (move.getName().equalsIgnoreCase(name) && active.canUse(move)) {
                 return move;
             }
         }
@@ -137,8 +136,7 @@ public class LLMAgent implements OpponentAgent, AutoCloseable {
             return null;
         }
         for (Move move : active.getMoves()) {
-            if (text.contains(move.getName().toLowerCase()) &&
-                    active.getStamina() >= move.getStaminaChange()) {
+            if (text.contains(move.getName().toLowerCase()) && active.canUse(move)) {
                 return move;
             }
         }

--- a/src/main/java/com/mesozoic/arena/ai/RandomOpponent.java
+++ b/src/main/java/com/mesozoic/arena/ai/RandomOpponent.java
@@ -29,7 +29,7 @@ public class RandomOpponent implements OpponentAgent {
     private List<Move> getUsableMoves(Dinosaur dinosaur) {
         List<Move> usable = new ArrayList<>();
         for (Move move : dinosaur.getMoves()) {
-            if (dinosaur.getStamina() >= move.getStaminaChange()) {
+            if (dinosaur.canUse(move)) {
                 usable.add(move);
             }
         }

--- a/src/main/java/com/mesozoic/arena/model/Dinosaur.java
+++ b/src/main/java/com/mesozoic/arena/model/Dinosaur.java
@@ -54,6 +54,17 @@ public class Dinosaur {
         return stamina;
     }
 
+    /**
+     * Indicates whether this dinosaur has enough stamina to perform the given
+     * move.
+     */
+    public boolean canUse(Move move) {
+        if (move == null) {
+            return false;
+        }
+        return stamina + move.getStaminaChange() >= 0;
+    }
+
     public List<Move> getMoves() {
         return new ArrayList<>(moves);
     }

--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -230,7 +230,6 @@ public class MainWindow extends JFrame {
     private void updateMoveButtons() {
         Dinosaur dino = player.getActiveDinosaur();
         List<Move> moves = dino == null ? new ArrayList<>() : dino.getMoves();
-        int stamina = dino == null ? 0 : dino.getStamina();
         for (int i = 0; i < moveButtons.length; i++) {
             JButton button = moveButtons[i];
             for (ActionListener l : button.getActionListeners()) {
@@ -239,7 +238,7 @@ public class MainWindow extends JFrame {
             if (i < moves.size()) {
                 Move move = moves.get(i);
                 button.setText(formatMoveLabel(dino, move));
-                boolean canUseMove = stamina >= move.getStaminaChange();
+                boolean canUseMove = dino != null && dino.canUse(move);
                 button.setEnabled(canUseMove);
                 if (canUseMove) {
                     button.addActionListener(e -> handlePlayerMove(move));


### PR DESCRIPTION
## Summary
- prevent negative stamina usage by adding `Dinosaur.canUse()`
- use `canUse()` when enabling move buttons
- use `canUse()` for the random and LLM agents

## Testing
- `mvn -q -DskipTests package`

------
https://chatgpt.com/codex/tasks/task_e_687445d554c0832eab38b053881127ea