### PR TITLE
Add turn counter and NPC thoughts log

### DIFF
--- a/src/main/java/com/mesozoic/arena/App.java
+++ b/src/main/java/com/mesozoic/arena/App.java
@@ -41,7 +41,7 @@ public class App {
     private static void announceWinner(Battle battle, Player player, Player opponent) {
         Player winner = battle.getWinner();
         if (winner != null) {
-            String label = winner == player ? "Player" : "Opponent";
+            String label = winner == player ? "Player" : "NPC";
             System.out.println(label + " wins!");
         }
     }

--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -22,6 +22,7 @@ public class MainWindow extends JFrame {
     private final DinoPanel playerPanel;
     private final DinoPanel opponentPanel;
     private final JTextArea logArea = new JTextArea(10,20);
+    private final JTextArea npcArea = new JTextArea(10,20);
 
     public MainWindow(Battle battle, Player player, Player opponent) {
         super("Mesozoic Arena");
@@ -40,6 +41,16 @@ public class MainWindow extends JFrame {
         split.setResizeWeight(0.5);
         add(split, BorderLayout.CENTER);
 
+        npcArea.setEditable(false);
+        npcArea.setLineWrap(true);
+        npcArea.setWrapStyleWord(true);
+        JPanel npcPanel = new JPanel(new BorderLayout());
+        JLabel npcLabel = new JLabel("NPC's thoughts", JLabel.CENTER);
+        npcPanel.add(npcLabel, BorderLayout.NORTH);
+        npcPanel.add(new JScrollPane(npcArea), BorderLayout.CENTER);
+        npcPanel.setPreferredSize(new Dimension(250, 100));
+        add(npcPanel, BorderLayout.EAST);
+
         logArea.setEditable(false);
         JButton exit = new JButton("Exit Game");
         exit.addActionListener(e -> System.exit(0));
@@ -56,6 +67,7 @@ public class MainWindow extends JFrame {
         updateDinoPanel(playerPanel,   player);
         updateDinoPanel(opponentPanel, opponent);
         logArea.setText(String.join("\n", battle.getEventLog()));
+        npcArea.setText(String.join("\n", battle.getAiLog()));
     }
 
     private void updateDinoPanel(DinoPanel panel, Player who) {


### PR DESCRIPTION
## Summary
- track turns and add AI log in `Battle`
- show NPC thoughts in new right-hand panel
- prefix move output with player labels and turn numbers
- update winner message for NPC label

## Testing
- `mvn -DskipTests=true package`

------
https://chatgpt.com/codex/tasks/task_e_68756cfe8654832e97241e6d3d17e8bd