### PR TITLE
Add turn history and include it in AI prompt

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/OpponentAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/OpponentAgent.java
@@ -2,6 +2,8 @@ package com.mesozoic.arena.ai;
 
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Player;
+import com.mesozoic.arena.engine.TurnRecord;
+import java.util.List;
 
 /**
  * Strategy interface for selecting a move in battle.
@@ -14,5 +16,5 @@ public interface OpponentAgent {
      * @param enemy the opposing dinosaur
      * @return the selected move or {@code null} if none can be performed
      */
-    Move chooseMove(Player self, Player enemy);
+    Move chooseMove(Player self, Player enemy, List<TurnRecord> history);
 }

--- a/src/main/java/com/mesozoic/arena/ai/RandomOpponent.java
+++ b/src/main/java/com/mesozoic/arena/ai/RandomOpponent.java
@@ -3,6 +3,7 @@ package com.mesozoic.arena.ai;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Player;
+import com.mesozoic.arena.engine.TurnRecord;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -14,7 +15,7 @@ public class RandomOpponent implements OpponentAgent {
     private final Random random = new Random();
 
     @Override
-    public Move chooseMove(Player self, Player enemy) {
+    public Move chooseMove(Player self, Player enemy, List<TurnRecord> history) {
         Dinosaur active = self.getActiveDinosaur();
         if (active == null) {
             return null;

--- a/src/main/java/com/mesozoic/arena/engine/TurnRecord.java
+++ b/src/main/java/com/mesozoic/arena/engine/TurnRecord.java
@@ -1,0 +1,22 @@
+package com.mesozoic.arena.engine;
+
+/**
+ * Captures the actions taken by both players during a single turn.
+ */
+public class TurnRecord {
+    private final String playerAction;
+    private final String npcAction;
+
+    public TurnRecord(String playerAction, String npcAction) {
+        this.playerAction = playerAction;
+        this.npcAction = npcAction;
+    }
+
+    public String getPlayerAction() {
+        return playerAction;
+    }
+
+    public String getNpcAction() {
+        return npcAction;
+    }
+}


### PR DESCRIPTION
## Summary
- track moves and switches each turn in `Battle`
- expose recorded turn history and pass it to opponent agents
- update opponent agent interface and implementations
- expand LLM prompt with last two turns of action history

## Testing
- `mvn -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68763d3376d4832eb383046a745b2728