### PR TITLE
Implement move and ability effects

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
@@ -168,14 +168,14 @@ public class LLMAgent implements OpponentAgent, AutoCloseable {
 
     private String formatMoves(Dinosaur dino) {
         return dino.getMoves().stream()
-                .map(m -> m.getName() + " (" + m.getDamage() * dino.getAttack() + " dmg, "
+                .map(m -> m.getName() + " (" + m.getDamage() * dino.getEffectiveAttack() + " dmg, "
                         + m.getStaminaChange() + " stamina, " + m.getPriority() + " priority)")
                 .collect(Collectors.joining(", "));
     }
 
     private String describeDinosaurStats(Dinosaur dino) {
         return dino.getName() + " (HP: " + dino.getHealth() + ", Stamina: "
-                + dino.getStamina() + ", Speed: " + dino.getSpeed() + ")\n";
+                + dino.getStamina() + ", Speed: " + dino.getEffectiveSpeed() + ")\n";
     }
 
     private String buildPrompt(Player selfPlayer, Player enemyPlayer, List<TurnRecord> history) {

--- a/src/main/java/com/mesozoic/arena/engine/AbilityEffects.java
+++ b/src/main/java/com/mesozoic/arena/engine/AbilityEffects.java
@@ -1,0 +1,53 @@
+package com.mesozoic.arena.engine;
+
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Ability;
+
+/**
+ * Utility methods for applying ability based effects.
+ */
+public final class AbilityEffects {
+    private AbilityEffects() {
+    }
+
+    /**
+     * Applies effects that trigger when a dinosaur enters the field.
+     *
+     * @param entering the dinosaur entering
+     * @param opponent the opposing active dinosaur
+     */
+    public static void onEntry(Dinosaur entering, Dinosaur opponent) {
+        if (entering == null) {
+            return;
+        }
+        Ability ability = entering.getAbility();
+        if (ability == null) {
+            return;
+        }
+        String name = ability.getName();
+        if ("Intimidate".equalsIgnoreCase(name) && opponent != null) {
+            opponent.adjustAttackStage(-1);
+        }
+    }
+
+    /**
+     * Modifies incoming damage based on the defender's ability.
+     */
+    public static int modifyIncomingDamage(Dinosaur defender, int damage) {
+        Ability ability = defender == null ? null : defender.getAbility();
+        if (ability != null && "Thick Skin".equalsIgnoreCase(ability.getName())) {
+            return Math.round(damage * 0.8f);
+        }
+        return damage;
+    }
+
+    /**
+     * Applies end of turn effects for the active dinosaur.
+     */
+    public static void endTurn(Dinosaur active) {
+        Ability ability = active == null ? null : active.getAbility();
+        if (ability != null && "Adrenaline".equalsIgnoreCase(ability.getName())) {
+            active.adjustStamina(10);
+        }
+    }
+}

--- a/src/main/java/com/mesozoic/arena/engine/MoveEffects.java
+++ b/src/main/java/com/mesozoic/arena/engine/MoveEffects.java
@@ -1,0 +1,39 @@
+package com.mesozoic.arena.engine;
+
+import com.mesozoic.arena.model.Effect;
+import com.mesozoic.arena.model.Move;
+
+/**
+ * Utility functions for processing move based effects.
+ */
+public final class MoveEffects {
+    private MoveEffects() {
+    }
+
+    /**
+     * Determines whether a move with a brace effect should activate based on the last action.
+     *
+     * @param move       the move being used
+     * @param lastAction the previous action taken by the same player, may be {@code null}
+     * @return {@code true} if the brace effect applies, otherwise {@code false}
+     */
+    public static boolean hasBraceEffect(Move move, String lastAction) {
+        if (move == null) {
+            return false;
+        }
+        boolean bracePresent = false;
+        for (Effect effect : move.getEffects()) {
+            if ("brace".equalsIgnoreCase(effect.getName())) {
+                bracePresent = true;
+                break;
+            }
+        }
+        if (!bracePresent) {
+            return false;
+        }
+        if (lastAction != null && "brace".equalsIgnoreCase(lastAction)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/mesozoic/arena/model/Dinosaur.java
+++ b/src/main/java/com/mesozoic/arena/model/Dinosaur.java
@@ -10,9 +10,11 @@ public class Dinosaur {
     private final String name;
     private int health;
     private final int speed;
+    private int speedStage = 0;
     private final String imagePath;
     private final Ability ability;
     private final int attack;
+    private int attackStage = 0;
     private int stamina;
     private final List<Move> moves;
 
@@ -84,5 +86,51 @@ public class Dinosaur {
         if (stamina > 100) {
             stamina = 100;
         }
+    }
+
+    public int getAttackStage() {
+        return attackStage;
+    }
+
+    public int getSpeedStage() {
+        return speedStage;
+    }
+
+    public void adjustAttackStage(int amount) {
+        attackStage = clampStage(attackStage + amount);
+    }
+
+    public void adjustSpeedStage(int amount) {
+        speedStage = clampStage(speedStage + amount);
+    }
+
+    public void resetStages() {
+        attackStage = 0;
+        speedStage = 0;
+    }
+
+    public int getEffectiveAttack() {
+        return Math.round((float) attack * stageMultiplier(attackStage));
+    }
+
+    public int getEffectiveSpeed() {
+        return Math.round((float) speed * stageMultiplier(speedStage));
+    }
+
+    private int clampStage(int stage) {
+        if (stage > 6) {
+            return 6;
+        }
+        if (stage < -6) {
+            return -6;
+        }
+        return stage;
+    }
+
+    private static float stageMultiplier(int stage) {
+        if (stage >= 0) {
+            return (2f + stage) / 2f;
+        }
+        return 2f / (2 - stage);
     }
 }

--- a/src/main/java/com/mesozoic/arena/model/Player.java
+++ b/src/main/java/com/mesozoic/arena/model/Player.java
@@ -32,6 +32,9 @@ public class Player {
 
     public void setActiveDinosaur(Dinosaur dinosaur) {
         if (dinosaurs.contains(dinosaur)) {
+            if (activeDinosaur != null && !activeDinosaur.equals(dinosaur)) {
+                activeDinosaur.resetStages();
+            }
             this.activeDinosaur = dinosaur;
         }
     }

--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -181,10 +181,9 @@ public class MainWindow extends JFrame {
     }
 
     private JButton createMoveButton(Dinosaur dino, Move move, boolean playerSide) {
+        int dmg = move.getDamage() * dino.getEffectiveAttack();
         JButton button = new JButton(
-                move.getName()
-                        + " (" + (move.getDamage() * dino.getAttack())
-                        + " / " + move.getStaminaChange() + ")"
+                move.getName() + " (" + dmg + " / " + move.getStaminaChange() + ")"
         );
         if (playerSide) {
             boolean canUse = dino.canUse(move);


### PR DESCRIPTION
## Summary
- implement `AbilityEffects` and `MoveEffects` helpers
- track attack/speed stages on dinosaurs
- reset stages on switch and modify damage/speed calculations
- show damage with modifiers in UI and LLM prompts

## Testing
- `mvn -DskipTests package`

------
https://chatgpt.com/codex/tasks/task_e_68766c2e0efc832e850d70463e8ac9b4