### PR TITLE
Display stat stage icons and add ability tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>snakeyaml</artifactId>
             <version>2.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -57,6 +63,14 @@
                 <configuration>
                     <mainClass>com.mesozoic.arena.App</mainClass>
                     <classpathScope>runtime</classpathScope>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -12,6 +12,7 @@ public class MainWindow extends JFrame {
     private static final String HEALTH_ICON_PATH  = "assets/icons/health.png";
     private static final String STAMINA_ICON_PATH = "assets/icons/energy.png";
     private static final String SPEED_ICON_PATH   = "assets/icons/speed.png";
+    private static final String ATTACK_ICON_PATH  = "assets/icons/attack.png";
 
     private static final int   BASE_STAT_ICON_SIZE   = 24;
     private static final int   BASE_STAT_FONT_SIZE   = 16;
@@ -74,8 +75,15 @@ public class MainWindow extends JFrame {
     private void updateDinoPanel(DinoPanel panel, Player who) {
         Dinosaur d = who.getActiveDinosaur();
 
-        // Name
-        panel.name.setText(d == null ? "None" : d.getName());
+        // Name with stage icons
+        if (d == null) {
+            panel.name.setText("None");
+        } else {
+            StringBuilder nameText = new StringBuilder(d.getName());
+            nameText.append(stageFragment(d.getAttackStage(), ATTACK_ICON_PATH));
+            nameText.append(stageFragment(d.getSpeedStage(), SPEED_ICON_PATH));
+            panel.name.setText("<html>" + nameText + "</html>");
+        }
 
         // Stats with icons
         setStatLabel(panel.health,  HEALTH_ICON_PATH,  d == null ? 0 : d.getHealth(),  true);
@@ -137,6 +145,19 @@ public class MainWindow extends JFrame {
         Image img = new ImageIcon(url).getImage()
                 .getScaledInstance(w, h, Image.SCALE_SMOOTH);
         return new ImageIcon(img);
+    }
+
+    private String stageFragment(int stage, String iconPath) {
+        if (stage == 0) {
+            return "";
+        }
+        java.net.URL url = getClass().getClassLoader().getResource(iconPath);
+        if (url == null) {
+            return " " + stage;
+        }
+        int size = Math.round(BASE_STAT_ICON_SIZE * 0.75f);
+        return " " + stage + "<img src='" + url + "' width='" + size
+                + "' height='" + size + "'/>";
     }
 
     /**

--- a/src/test/java/com/mesozoic/arena/DinosaurTest.java
+++ b/src/test/java/com/mesozoic/arena/DinosaurTest.java
@@ -1,0 +1,44 @@
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.Ability;
+import com.mesozoic.arena.model.Player;
+import com.mesozoic.arena.engine.Battle;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+
+public class DinosaurTest {
+    @Test
+    public void testStageAffectsStats() {
+        Dinosaur dino = new Dinosaur("Test", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(), null);
+        assertEquals(10, dino.getEffectiveAttack());
+        assertEquals(50, dino.getEffectiveSpeed());
+        dino.adjustAttackStage(1);
+        dino.adjustSpeedStage(-1);
+        assertEquals(15, dino.getEffectiveAttack());
+        assertEquals(33, dino.getEffectiveSpeed());
+    }
+
+    @Test
+    public void testStagesResetOnBench() {
+        Dinosaur first = new Dinosaur("First", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(), null);
+        Dinosaur second = new Dinosaur("Second", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(), null);
+        Player player = new Player(List.of(first, second));
+        first.adjustAttackStage(2);
+        first.adjustSpeedStage(-2);
+        player.setActiveDinosaur(second);
+        assertEquals(0, first.getAttackStage());
+        assertEquals(0, first.getSpeedStage());
+    }
+
+    @Test
+    public void testIntimidateLowersOpponentAttack() {
+        Ability intimidate = new Ability("Intimidate", "");
+        Dinosaur intimidator = new Dinosaur("Intimidator", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(), intimidate);
+        Dinosaur target = new Dinosaur("Target", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(), null);
+        Player p1 = new Player(List.of(intimidator));
+        Player p2 = new Player(List.of(target));
+        new Battle(p1, p2); // ability triggers on battle start
+        assertEquals(-1, target.getAttackStage());
+    }
+}


### PR DESCRIPTION
## Summary
- show attack and speed stage icons next to dinosaur names
- support new JUnit tests in Maven
- add tests covering stat stage math, resets, and intimidate ability

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68767eaa386c832e95f3d4b3be9ec475