### PR TITLE
Implement healing move effects

### DIFF
--- a/data/effects.yaml
+++ b/data/effects.yaml
@@ -1,1 +1,3 @@
 brace: Negates damage from the next attack after use.
+heal: Restores 30 HP to the active dinosaur.
+area heal: Restores 10 HP to all dinosaurs on the team.

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -188,6 +188,7 @@ public class Battle {
 
         // apply move effects
         attacker.adjustStamina(move.getStaminaChange());
+        applyMoveEffects(actingPlayer, move);
         if (!defenderBraced) {
             int totalDamage = move.getDamage() * attacker.getEffectiveAttack();
             totalDamage = AbilityEffects.modifyIncomingDamage(defender, totalDamage);
@@ -253,6 +254,20 @@ public class Battle {
         for (Dinosaur dinosaur : player.getDinosaurs()) {
             if (!dinosaur.equals(active)) {
                 dinosaur.adjustStamina(10);
+            }
+        }
+    }
+
+    private void applyMoveEffects(Player player, Move move) {
+        if (MoveEffects.containsEffect(move, "heal")) {
+            Dinosaur active = player.getActiveDinosaur();
+            if (active != null) {
+                active.adjustHealth(30);
+            }
+        }
+        if (MoveEffects.containsEffect(move, "area heal")) {
+            for (Dinosaur dinosaur : player.getDinosaurs()) {
+                dinosaur.adjustHealth(10);
             }
         }
     }

--- a/src/main/java/com/mesozoic/arena/engine/MoveEffects.java
+++ b/src/main/java/com/mesozoic/arena/engine/MoveEffects.java
@@ -11,6 +11,21 @@ public final class MoveEffects {
     }
 
     /**
+     * Checks if the given move has an effect with the specified name.
+     */
+    public static boolean containsEffect(Move move, String effectName) {
+        if (move == null || effectName == null) {
+            return false;
+        }
+        for (Effect effect : move.getEffects()) {
+            if (effectName.equalsIgnoreCase(effect.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Determines whether a move with a brace effect should activate based on the last action.
      *
      * @param move       the move being used
@@ -18,17 +33,7 @@ public final class MoveEffects {
      * @return {@code true} if the brace effect applies, otherwise {@code false}
      */
     public static boolean hasBraceEffect(Move move, String lastAction) {
-        if (move == null) {
-            return false;
-        }
-        boolean bracePresent = false;
-        for (Effect effect : move.getEffects()) {
-            if ("brace".equalsIgnoreCase(effect.getName())) {
-                bracePresent = true;
-                break;
-            }
-        }
-        if (!bracePresent) {
+        if (!containsEffect(move, "brace")) {
             return false;
         }
         if (lastAction != null && "brace".equalsIgnoreCase(lastAction)) {

--- a/src/main/java/com/mesozoic/arena/model/Dinosaur.java
+++ b/src/main/java/com/mesozoic/arena/model/Dinosaur.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class Dinosaur {
     private final String name;
     private int health;
+    private final int maxHealth;
     private final int speed;
     private int speedStage = 0;
     private final String imagePath;
@@ -22,6 +23,7 @@ public class Dinosaur {
             List<Move> moves, Ability ability) {
         this.name = name;
         this.health = health;
+        this.maxHealth = health;
         this.speed = speed;
         this.imagePath = imagePath;
         this.ability = ability;
@@ -40,6 +42,10 @@ public class Dinosaur {
 
     public int getHealth() {
         return health;
+    }
+
+    public int getMaxHealth() {
+        return maxHealth;
     }
 
     public int getSpeed() {
@@ -79,6 +85,9 @@ public class Dinosaur {
 
     public void adjustHealth(int amount) {
         health += amount;
+        if (health > maxHealth) {
+            health = maxHealth;
+        }
     }
 
     public void adjustStamina(int amount) {

--- a/src/test/java/com/mesozoic/arena/MoveEffectsTest.java
+++ b/src/test/java/com/mesozoic/arena/MoveEffectsTest.java
@@ -1,0 +1,52 @@
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.Effect;
+import com.mesozoic.arena.model.Player;
+import com.mesozoic.arena.engine.Battle;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+public class MoveEffectsTest {
+    @Test
+    public void testAreaHealHealsWholeTeam() {
+        Move areaHeal = new Move("Rally", 0, 0, 0, List.of(new Effect("area heal")));
+        Move noop = new Move("Wait", 0, 0, 0, List.of());
+        Dinosaur active = new Dinosaur("Active", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(areaHeal), null);
+        Dinosaur bench = new Dinosaur("Bench", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null);
+        Player p1 = new Player(List.of(active, bench));
+        Player p2 = new Player(List.of(new Dinosaur("Opponent", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null)));
+        Battle battle = new Battle(p1, p2);
+
+        active.adjustHealth(-20);
+        bench.adjustHealth(-40);
+        battle.executeRound(areaHeal, noop);
+
+        assertEquals(90, active.getHealth());
+        assertEquals(70, bench.getHealth());
+    }
+
+    @Test
+    public void testHealCapsAtMax() {
+        Move heal = new Move("Recover", 0, 0, 0, List.of(new Effect("heal")));
+        Move noop = new Move("Wait", 0, 0, 0, List.of());
+        Dinosaur active = new Dinosaur("Active", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(heal), null);
+        Dinosaur bench = new Dinosaur("Bench", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null);
+        Player p1 = new Player(List.of(active, bench));
+        Player p2 = new Player(List.of(new Dinosaur("Opponent", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null)));
+        Battle battle = new Battle(p1, p2);
+
+        active.adjustHealth(-80); // 20 health left
+        bench.adjustHealth(-10);  // should remain unchanged by heal
+        battle.executeRound(heal, noop);
+
+        assertEquals(50, active.getHealth());
+        assertEquals(90, bench.getHealth());
+
+        // heal again to test cap at max health
+        battle.executeRound(heal, noop);
+        assertEquals(80, active.getHealth());
+    }
+}


### PR DESCRIPTION
## Summary
- store each dinosaur's max health when created
- stop healing beyond that maximum
- add generic move effect lookup helper
- apply `heal` and `area heal` move effects in battle logic
- document new effects
- test healing effects

## Testing
- `mvn test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_6876857a7508832ebf1986f5156f8614