### PR TITLE
Add Supporter and Berserk abilities

### DIFF
--- a/data/abilities.yaml
+++ b/data/abilities.yaml
@@ -4,3 +4,5 @@ Adrenaline: Regenerates stamina each turn.
 Intimidate: Lowers the opponent's attack by one stage on entry.
 Spiky Body: Reflects 10 damage when hit by an attack.
 Armored: Reduces incoming damage by 10.
+Supporter: 0 damage moves gain +1 priority.
+Berserk: Attack increases by one stage after each knockout.

--- a/src/main/java/com/mesozoic/arena/engine/AbilityEffects.java
+++ b/src/main/java/com/mesozoic/arena/engine/AbilityEffects.java
@@ -54,6 +54,25 @@ public final class AbilityEffects {
     }
 
     /**
+     * Adjusts move priority based on the user's ability.
+     *
+     * @param user the dinosaur performing the move
+     * @param move the move being used
+     * @return the priority after ability modifications
+     */
+    public static int modifyPriority(Dinosaur user, Move move) {
+        if (user == null || move == null) {
+            return move == null ? 0 : move.getPriority();
+        }
+        Ability ability = user.getAbility();
+        if (ability != null && "Supporter".equalsIgnoreCase(ability.getName())
+                && move.getDamage() == 0) {
+            return move.getPriority() + 1;
+        }
+        return move.getPriority();
+    }
+
+    /**
      * Applies effects after a dinosaur has been attacked.
      *
      * @param attacker the dinosaur that initiated the attack
@@ -79,6 +98,22 @@ public final class AbilityEffects {
         Ability ability = active == null ? null : active.getAbility();
         if (ability != null && "Adrenaline".equalsIgnoreCase(ability.getName())) {
             active.adjustStamina(10);
+        }
+    }
+
+    /**
+     * Triggers effects when the user knocks out an opposing dinosaur.
+     *
+     * @param attacker the dinosaur delivering the final blow
+     * @param defender the dinosaur that fainted
+     */
+    public static void onKnockOut(Dinosaur attacker, Dinosaur defender) {
+        if (attacker == null || defender == null) {
+            return;
+        }
+        Ability ability = attacker.getAbility();
+        if (ability != null && "Berserk".equalsIgnoreCase(ability.getName())) {
+            attacker.adjustAttackStage(1);
         }
     }
 }

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -115,8 +115,10 @@ public class Battle {
             return;
         }
 
-        int p1Priority = playerOneMove == null ? Integer.MIN_VALUE : playerOneMove.getPriority();
-        int p2Priority = playerTwoMove == null ? Integer.MIN_VALUE : playerTwoMove.getPriority();
+        int p1Priority = playerOneMove == null ? Integer.MIN_VALUE
+                : AbilityEffects.modifyPriority(dinoOne, playerOneMove);
+        int p2Priority = playerTwoMove == null ? Integer.MIN_VALUE
+                : AbilityEffects.modifyPriority(dinoTwo, playerTwoMove);
         boolean p1First;
         if (p1Priority != p2Priority) {
             p1First = p1Priority > p2Priority;
@@ -216,6 +218,10 @@ public class Battle {
             }
 
             AbilityEffects.onAttacked(attacker, defender, move);
+            boolean faintedThisHit = defender.getHealth() <= 0;
+            if (faintedThisHit) {
+                AbilityEffects.onKnockOut(attacker, defender);
+            }
             Dinosaur beforeDefender = defender;
             checkFaint(opposingPlayer);
             checkFaint(actingPlayer);

--- a/src/test/java/com/mesozoic/arena/AbilityEffectsTest.java
+++ b/src/test/java/com/mesozoic/arena/AbilityEffectsTest.java
@@ -3,6 +3,7 @@ import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Ability;
 import com.mesozoic.arena.model.Player;
 import com.mesozoic.arena.engine.Battle;
+import com.mesozoic.arena.engine.AbilityEffects;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -53,6 +54,42 @@ public class AbilityEffectsTest {
 
         assertEquals(100, attacker.getHealth());
         assertEquals(95, armored.getHealth());
+    }
+
+    @Test
+    public void testSupporterAddsPriority() {
+        Move cheer = new Move("Cheer", 0, 0, 0, List.of());
+        Dinosaur helper = new Dinosaur(
+                "Helper", 100, 50, "assets/animals/allosaurus.png", 100, 10,
+                List.of(cheer), new Ability("Supporter", ""));
+
+        int modified = AbilityEffects.modifyPriority(helper, cheer);
+        assertEquals(1, modified);
+
+        Move strike = new Move("Strike", 5, 0, 0, List.of());
+        modified = AbilityEffects.modifyPriority(helper, strike);
+        assertEquals(0, modified);
+    }
+
+    @Test
+    public void testBerserkRaisesAttackOnKnockout() {
+        Move strike = new Move("Strike", 20, 0, 0, List.of());
+        Move waitMove = new Move("Wait", 0, 0, 0, List.of());
+
+        Dinosaur berserker = new Dinosaur(
+                "Berserker", 100, 50, "assets/animals/allosaurus.png", 100, 10,
+                List.of(strike), new Ability("Berserk", ""));
+        Dinosaur target = new Dinosaur(
+                "Target", 20, 50, "assets/animals/allosaurus.png", 100, 10,
+                List.of(waitMove), null);
+
+        Player p1 = new Player(List.of(berserker));
+        Player p2 = new Player(List.of(target));
+        Battle battle = new Battle(p1, p2);
+
+        battle.executeRound(strike, waitMove);
+
+        assertEquals(1, berserker.getAttackStage());
     }
 }
 


### PR DESCRIPTION
## Summary
- implement Supporter and Berserk ability effects
- adjust battle logic to use ability-modified priority and knock out triggers
- document new abilities
- test ability behaviour

## Testing
- `mvn test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_6876c0bbdc58832eaaf09841af577254