### PR TITLE
Add move descriptions with dynamic damage

### DIFF
--- a/data/moves.yaml
+++ b/data/moves.yaml
@@ -3,69 +3,81 @@ Bite:
   stamina: -30
   priority: 0
   effects: []
+  description: "Bite the opponent for X damage."
 
 Brace:
   damage: 0
   stamina: -10
   priority: 2
   effects: [brace]
+  description: "Brace yourself to reduce incoming attacks for X damage."
 
 Charge:
   damage: 40
   stamina: -40
   priority: 1
   effects: []
+  description: "Charge forward to slam the foe for X damage."
 
 Double Scratch:
   damage: 18
   stamina: -25
   priority: 0
   effects: [double attack]
+  description: "Scratch twice for a total of X damage."
 
 Kick:
   damage: 30
   stamina: -20
   priority: 0
   effects: []
+  description: "Deliver a powerful kick for X damage."
 
 Heal:
   damage: 0
   stamina: -20
   priority: 1
   effects: [heal]
+  description: "Recover health while dealing X damage."
 
 Impale:
   damage: 40
   stamina: -30
   priority: 0
   effects: []
+  description: "Impale the foe with your horns for X damage."
 
 Roar:
   damage: 0
   stamina: 30
   priority: 0
   effects: []
+  description: "Roar loudly to intimidate for X damage."
 
 Scratch:
   damage: 20
   stamina: 0
   priority: 0
   effects: []
+  description: "Scratch the target for X damage."
 
 Tail Swipe:
   damage: 30
   stamina: -20
   priority: 0
   effects: []
+  description: "Swipe your tail for X damage."
 
 Thagomizer Swipe:
   damage: 40
   stamina: -30
   priority: 0
   effects: []
+  description: "Swing your spiked tail for X damage."
 
 Stomp:
   damage: 10
   stamina: 0
   priority: 0
   effects: []
+  description: "Stomp the ground for X damage."

--- a/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/LLMAgent.java
@@ -168,8 +168,7 @@ public class LLMAgent implements OpponentAgent, AutoCloseable {
 
     private String formatMoves(Dinosaur dino) {
         return dino.getMoves().stream()
-                .map(m -> m.getName() + " (" + Math.round(m.getDamage() * dino.getEffectiveAttack()) + " dmg, "
-                        + m.getStaminaChange() + " stamina, " + m.getPriority() + " priority)")
+                .map(m -> m.getName() + ": " + m.getDescriptionWithDamage(dino))
                 .collect(Collectors.joining(", "));
     }
 

--- a/src/main/java/com/mesozoic/arena/data/DinosaurLoader.java
+++ b/src/main/java/com/mesozoic/arena/data/DinosaurLoader.java
@@ -106,7 +106,7 @@ public class DinosaurLoader {
                 if (template != null) {
                     moves.add(new Move(template.getName(), template.getDamage(),
                             template.getStaminaChange(), template.getPriority(),
-                            template.getEffects()));
+                            template.getDescription(), template.getEffects()));
                 }
             }
         }
@@ -137,7 +137,8 @@ public class DinosaurLoader {
         List<Move> copiedMoves = new ArrayList<>();
         for (Move move : source.getMoves()) {
             copiedMoves.add(new Move(move.getName(), move.getDamage(),
-                    move.getStaminaChange(), move.getPriority(), move.getEffects()));
+                    move.getStaminaChange(), move.getPriority(),
+                    move.getDescription(), move.getEffects()));
         }
         return new Dinosaur(source.getName(), source.getHealth(), source.getSpeed(), source.getImagePath(),
                 source.getStamina(), source.getAttack(), copiedMoves, source.getAbility());
@@ -157,8 +158,9 @@ public class DinosaurLoader {
                     int damage = ((Number) values.getOrDefault("damage", 0)).intValue();
                     int stamina = ((Number) values.getOrDefault("stamina", 0)).intValue();
                     int priority = ((Number) values.getOrDefault("priority", 0)).intValue();
+                    String description = String.valueOf(values.getOrDefault("description", ""));
                     List<Effect> effects = parseEffects(values.get("effects"));
-                    map.put(name, new Move(name, damage, stamina, priority, effects));
+                    map.put(name, new Move(name, damage, stamina, priority, description, effects));
                 }
             }
         }

--- a/src/main/java/com/mesozoic/arena/model/Move.java
+++ b/src/main/java/com/mesozoic/arena/model/Move.java
@@ -12,8 +12,13 @@ public class Move {
     private final int staminaChange;
     private final int priority;
     private final List<Effect> effects;
+    private final String description;
 
     public Move(String name, int damage, int staminaChange, int priority, List<Effect> effects) {
+        this(name, damage, staminaChange, priority, "", effects);
+    }
+
+    public Move(String name, int damage, int staminaChange, int priority, String description, List<Effect> effects) {
         this.name = name;
         this.damage = damage;
         this.staminaChange = staminaChange;
@@ -23,6 +28,7 @@ public class Move {
         } else {
             this.effects = new ArrayList<>(effects);
         }
+        this.description = description == null ? "" : description;
     }
 
     public String getName() {
@@ -43,5 +49,14 @@ public class Move {
 
     public List<Effect> getEffects() {
         return new ArrayList<>(effects);
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getDescriptionWithDamage(Dinosaur user) {
+        long realDamage = Math.round(damage * user.getEffectiveAttack());
+        return description.replace("X", String.valueOf(realDamage));
     }
 }


### PR DESCRIPTION
## Summary
- describe each move in `moves.yaml` with a placeholder for damage
- extend `Move` to store descriptions and compute real damage strings
- load descriptions in `DinosaurLoader`
- copy descriptions when cloning moves
- format move info for the LLM using descriptions with real damage

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6876e3801ee4832ea4af21ee5e3637a4