### PR TITLE
Add move type and split attack stats

### DIFF
--- a/data/animals.yaml
+++ b/data/animals.yaml
@@ -1,7 +1,8 @@
 Allosaurus:
   health: 140
   speed: 100
-  attack: 1.0
+  head attack: 1.0
+  body attack: 1.0
   ability: None
   image: assets/animals/allosaurus.png
   moves:
@@ -13,7 +14,8 @@ Allosaurus:
 Ceratosaurus:
   health: 110
   speed: 110
-  attack: 0.95
+  head attack: 0.95
+  body attack: 0.95
   ability: None
   image: assets/animals/ceratosaurus.png
   moves:
@@ -25,7 +27,8 @@ Ceratosaurus:
 Corythosaurus:
   health: 140
   speed: 95
-  attack: 0.7
+  head attack: 0.7
+  body attack: 0.7
   ability: None
   image: assets/animals/corythosaurus.png
   moves:
@@ -37,7 +40,8 @@ Corythosaurus:
 Stegosaurus:
   health: 160
   speed: 60
-  attack: 1.0
+  head attack: 1.0
+  body attack: 1.0
   ability: Spiky Body
   image: assets/animals/stegosaurus.png
   moves:
@@ -49,7 +53,8 @@ Stegosaurus:
 Styracosaurus:
   health: 90
   speed: 60
-  attack: 0.8
+  head attack: 0.8
+  body attack: 0.8
   ability: Intimidate
   image: assets/animals/styracosaurus.png
   moves:

--- a/data/moves.yaml
+++ b/data/moves.yaml
@@ -4,6 +4,7 @@ Bite:
   priority: 0
   effects: []
   description: "Deal XX damage. Costs YY stamina."
+  type: head
 
 Brace:
   damage: 0
@@ -11,6 +12,7 @@ Brace:
   priority: 2
   effects: [brace]
   description: "Prevent all damage dealt to you next turn. Fails if it was already used last turn. +2 Priority. Costs YY stamina."
+  type: body
 
 Charge:
   damage: 40
@@ -18,6 +20,7 @@ Charge:
   priority: 1
   effects: []
   description: "Deal XX damage. +1 Priority. Costs YY stamina."
+  type: body
 
 Double Scratch:
   damage: 18
@@ -25,6 +28,7 @@ Double Scratch:
   priority: 0
   effects: [double attack]
   description: "Attack twice for XX damage each. Costs YY stamina."
+  type: body
 
 Kick:
   damage: 30
@@ -32,6 +36,7 @@ Kick:
   priority: 0
   effects: []
   description: "Deal XX damage. Costs YY stamina."
+  type: body
 
 Heal:
   damage: 0
@@ -39,6 +44,7 @@ Heal:
   priority: 1
   effects: [heal]
   description: "Recover 30 health. +1 Priority."
+  type: body
 
 Impale:
   damage: 40
@@ -46,6 +52,7 @@ Impale:
   priority: 0
   effects: []
   description: "Deal XX damage. Costs YY stamina."
+  type: head
 
 Roar:
   damage: 0
@@ -53,6 +60,7 @@ Roar:
   priority: 0
   effects: []
   description: "Gain YY stamina."
+  type: head
 
 Scratch:
   damage: 20
@@ -60,6 +68,7 @@ Scratch:
   priority: 0
   effects: []
   description: "Deal XX damage. Costs YY stamina."
+  type: body
 
 Tail Swipe:
   damage: 30
@@ -67,6 +76,7 @@ Tail Swipe:
   priority: 0
   effects: []
   description: "Deal XX damage. Costs YY stamina."
+  type: body
 
 Thagomizer Swipe:
   damage: 40
@@ -74,6 +84,7 @@ Thagomizer Swipe:
   priority: 0
   effects: []
   description: "Deal XX damage. Costs YY stamina."
+  type: body
 
 Stomp:
   damage: 10
@@ -81,3 +92,4 @@ Stomp:
   priority: 0
   effects: []
   description: "Deal XX damage. Costs YY stamina."
+  type: body

--- a/src/main/java/com/mesozoic/arena/data/DinosaurLoader.java
+++ b/src/main/java/com/mesozoic/arena/data/DinosaurLoader.java
@@ -3,6 +3,7 @@ package com.mesozoic.arena.data;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Effect;
 import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.MoveType;
 import com.mesozoic.arena.model.Ability;
 import com.mesozoic.arena.model.Player;
 import org.yaml.snakeyaml.Yaml;
@@ -84,7 +85,9 @@ public class DinosaurLoader {
     private Dinosaur parseDinosaur(String name, Map<String, Object> values) throws IOException {
         int health = ((Number) values.get("health")).intValue();
         int speed = ((Number) values.get("speed")).intValue();
-        double attack = ((Number) values.getOrDefault("attack", 1)).doubleValue();
+        double defaultAttack = ((Number) values.getOrDefault("attack", 1)).doubleValue();
+        double headAttack = ((Number) values.getOrDefault("head attack", defaultAttack)).doubleValue();
+        double bodyAttack = ((Number) values.getOrDefault("body attack", defaultAttack)).doubleValue();
         String imagePath = (String) values.get("image");
         validateImageExists(imagePath);
 
@@ -95,7 +98,7 @@ public class DinosaurLoader {
         String abilityName = String.valueOf(values.getOrDefault("ability", "None"));
         Ability ability = abilityTemplates.get(abilityName);
 
-        return new Dinosaur(name, health, speed, imagePath, 100, attack, moves, ability);
+        return new Dinosaur(name, health, speed, imagePath, 100, headAttack, bodyAttack, moves, ability);
     }
 
     private List<Move> resolveMoves(List<String> names) {
@@ -141,7 +144,7 @@ public class DinosaurLoader {
                     move.getDescription(), move.getEffects()));
         }
         return new Dinosaur(source.getName(), source.getHealth(), source.getSpeed(), source.getImagePath(),
-                source.getStamina(), source.getAttack(), copiedMoves, source.getAbility());
+                source.getStamina(), source.getHeadAttack(), source.getBodyAttack(), copiedMoves, source.getAbility());
     }
 
     private Map<String, Move> loadMoves() throws IOException {
@@ -159,8 +162,10 @@ public class DinosaurLoader {
                     int stamina = ((Number) values.getOrDefault("stamina", 0)).intValue();
                     int priority = ((Number) values.getOrDefault("priority", 0)).intValue();
                     String description = String.valueOf(values.getOrDefault("description", ""));
+                    String typeLabel = String.valueOf(values.getOrDefault("type", "body"));
+                    MoveType type = "head".equalsIgnoreCase(typeLabel) ? MoveType.HEAD : MoveType.BODY;
                     List<Effect> effects = parseEffects(values.get("effects"));
-                    map.put(name, new Move(name, damage, stamina, priority, description, effects));
+                    map.put(name, new Move(name, damage, stamina, priority, description, type, effects));
                 }
             }
         }

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -6,6 +6,7 @@ import com.mesozoic.arena.ai.RandomOpponent;
 import com.mesozoic.arena.util.Config;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.MoveType;
 import com.mesozoic.arena.model.Player;
 import com.mesozoic.arena.engine.MoveEffects;
 import com.mesozoic.arena.engine.AbilityEffects;
@@ -198,7 +199,10 @@ public class Battle {
             attacker.adjustStamina(move.getStaminaChange());
             applyMoveEffects(actingPlayer, opposingPlayer, move);
             if (!defenderBraced) {
-                int totalDamage = Math.toIntExact(Math.round(move.getDamage() * attacker.getEffectiveAttack()));
+                double attackValue = move.getType() == MoveType.HEAD
+                        ? attacker.getEffectiveHeadAttack()
+                        : attacker.getEffectiveBodyAttack();
+                int totalDamage = Math.toIntExact(Math.round(move.getDamage() * attackValue));
                 totalDamage = AbilityEffects.modifyIncomingDamage(defender, totalDamage);
                 int beforeHealth = defender.getHealth();
                 defender.adjustHealth(-totalDamage);

--- a/src/main/java/com/mesozoic/arena/model/Dinosaur.java
+++ b/src/main/java/com/mesozoic/arena/model/Dinosaur.java
@@ -14,21 +14,23 @@ public class Dinosaur {
     private int speedStage = 0;
     private final String imagePath;
     private final Ability ability;
-    private final double attack;
+    private final double headAttack;
+    private final double bodyAttack;
     private int attackStage = 0;
     private int stamina;
     private final List<Move> moves;
     private final List<Ailment> ailments = new ArrayList<>();
 
-    public Dinosaur(String name, int health, int speed, String imagePath, int stamina, double attack,
-                    List<Move> moves, Ability ability) {
+    public Dinosaur(String name, int health, int speed, String imagePath, int stamina,
+                    double headAttack, double bodyAttack, List<Move> moves, Ability ability) {
         this.name = name;
         this.health = health;
         this.maxHealth = health;
         this.speed = speed;
         this.imagePath = imagePath;
         this.ability = ability;
-        this.attack = attack;
+        this.headAttack = headAttack;
+        this.bodyAttack = bodyAttack;
         this.stamina = stamina;
         if (moves == null) {
             this.moves = new ArrayList<>();
@@ -57,8 +59,12 @@ public class Dinosaur {
         return imagePath;
     }
 
-    public double getAttack() {
-        return attack;
+    public double getHeadAttack() {
+        return headAttack;
+    }
+
+    public double getBodyAttack() {
+        return bodyAttack;
     }
 
     public Ability getAbility() {
@@ -151,8 +157,12 @@ public class Dinosaur {
         speedStage = 0;
     }
 
-    public double getEffectiveAttack() {
-        return attack * stageMultiplier(attackStage);
+    public double getEffectiveHeadAttack() {
+        return headAttack * stageMultiplier(attackStage);
+    }
+
+    public double getEffectiveBodyAttack() {
+        return bodyAttack * stageMultiplier(attackStage);
     }
 
     public int getEffectiveSpeed() {

--- a/src/main/java/com/mesozoic/arena/model/Move.java
+++ b/src/main/java/com/mesozoic/arena/model/Move.java
@@ -13,12 +13,17 @@ public class Move {
     private final int priority;
     private final List<Effect> effects;
     private final String description;
+    private final MoveType type;
 
     public Move(String name, int damage, int staminaChange, int priority, List<Effect> effects) {
-        this(name, damage, staminaChange, priority, "", effects);
+        this(name, damage, staminaChange, priority, "", MoveType.BODY, effects);
     }
 
     public Move(String name, int damage, int staminaChange, int priority, String description, List<Effect> effects) {
+        this(name, damage, staminaChange, priority, description, MoveType.BODY, effects);
+    }
+
+    public Move(String name, int damage, int staminaChange, int priority, String description, MoveType type, List<Effect> effects) {
         this.name = name;
         this.damage = damage;
         this.staminaChange = staminaChange;
@@ -29,6 +34,7 @@ public class Move {
             this.effects = new ArrayList<>(effects);
         }
         this.description = description == null ? "" : description;
+        this.type = type == null ? MoveType.BODY : type;
     }
 
     public String getName() {
@@ -55,8 +61,15 @@ public class Move {
         return description;
     }
 
+    public MoveType getType() {
+        return type;
+    }
+
     public String getDescriptionWithDamageAndStamina(Dinosaur user) {
-        long realDamage = Math.round(damage * user.getEffectiveAttack());
+        double attackValue = type == MoveType.HEAD
+                ? user.getEffectiveHeadAttack()
+                : user.getEffectiveBodyAttack();
+        long realDamage = Math.round(damage * attackValue);
         String descriptionWithStamina = description.replace("YY", String.valueOf(Math.abs(staminaChange)));
         return descriptionWithStamina.replace("XX", String.valueOf(realDamage));
     }

--- a/src/main/java/com/mesozoic/arena/model/MoveType.java
+++ b/src/main/java/com/mesozoic/arena/model/MoveType.java
@@ -1,0 +1,9 @@
+package com.mesozoic.arena.model;
+
+/**
+ * Indicates whether a move uses the dinosaur's head or body.
+ */
+public enum MoveType {
+    HEAD,
+    BODY
+}

--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -3,6 +3,7 @@ package com.mesozoic.arena.ui;
 import com.mesozoic.arena.engine.Battle;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.MoveType;
 import com.mesozoic.arena.model.Player;
 
 import javax.swing.*;
@@ -202,7 +203,10 @@ public class MainWindow extends JFrame {
     }
 
     private JButton createMoveButton(Dinosaur dino, Move move, boolean playerSide) {
-        int dmg = Math.toIntExact(Math.round(move.getDamage() * dino.getEffectiveAttack()));
+        double attackValue = move.getType() == MoveType.HEAD
+                ? dino.getEffectiveHeadAttack()
+                : dino.getEffectiveBodyAttack();
+        int dmg = Math.toIntExact(Math.round(move.getDamage() * attackValue));
         JButton button = new JButton(
                 move.getName() + " (" + dmg + " / " + move.getStaminaChange() + ")"
         );

--- a/src/main/java/com/mesozoic/arena/util/DinosaurLoader.java
+++ b/src/main/java/com/mesozoic/arena/util/DinosaurLoader.java
@@ -3,6 +3,7 @@ package com.mesozoic.arena.util;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Effect;
 import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.MoveType;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -39,6 +40,8 @@ public final class DinosaurLoader {
                 int damage = toInt(val.get("damage"));
                 int stamina = toInt(val.get("stamina"));
                 int priority = toInt(val.getOrDefault("priority", 0));
+                String typeLabel = String.valueOf(val.getOrDefault("type", "body"));
+                MoveType type = "head".equalsIgnoreCase(typeLabel) ? MoveType.HEAD : MoveType.BODY;
                 List<Effect> effects = new ArrayList<>();
                 List<?> eff = castObjectList(val.get("effects"));
                 if (eff != null) {
@@ -48,7 +51,7 @@ public final class DinosaurLoader {
                         }
                     }
                 }
-                moves.put(name, new Move(name, damage, stamina, priority, effects));
+                moves.put(name, new Move(name, damage, stamina, priority, "", type, effects));
             }
 
             Map<String, Object> data = yaml.load(dinoStream);
@@ -58,7 +61,9 @@ public final class DinosaurLoader {
                 Map<String, Object> dinoData = castMap(entry.getValue());
                 int health = toInt(dinoData.get("health"));
                 int speed = toInt(dinoData.get("speed"));
-                int attack = toInt(dinoData.getOrDefault("attack", 10));
+                int defaultAttack = toInt(dinoData.getOrDefault("attack", 10));
+                int headAttack = toInt(dinoData.getOrDefault("head attack", defaultAttack));
+                int bodyAttack = toInt(dinoData.getOrDefault("body attack", defaultAttack));
                 String image = String.valueOf(dinoData.get("image"));
                 List<?> moveNames = castObjectList(dinoData.get("moves"));
                 List<Move> dinoMoves = new ArrayList<>();
@@ -67,11 +72,12 @@ public final class DinosaurLoader {
                         Move m = moves.get(String.valueOf(n));
                         if (m != null) {
                             dinoMoves.add(new Move(m.getName(), m.getDamage(),
-                                    m.getStaminaChange(), m.getPriority(), m.getEffects()));
+                                    m.getStaminaChange(), m.getPriority(), m.getDescription(), m.getType(),
+                                    m.getEffects()));
                         }
                     }
                 }
-                dinosaurs.add(new Dinosaur(name, health, speed, image, 100, attack,
+                dinosaurs.add(new Dinosaur(name, health, speed, image, 100, headAttack, bodyAttack,
                         dinoMoves, null));
             }
             return dinosaurs;

--- a/src/test/java/com/mesozoic/arena/AbilityEffectsTest.java
+++ b/src/test/java/com/mesozoic/arena/AbilityEffectsTest.java
@@ -19,10 +19,10 @@ public class AbilityEffectsTest {
 
         Dinosaur attacker = new Dinosaur(
                 "Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 1,
-                List.of(strike), null);
+                1, List.of(strike), null);
         Dinosaur spiky = new Dinosaur(
                 "Spiky", 100, 50, "assets/animals/allosaurus.png", 100, 10,
-                List.of(waitMove), new Ability("Spiky Body", ""));
+                10, List.of(waitMove), new Ability("Spiky Body", ""));
 
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(spiky));
@@ -41,10 +41,10 @@ public class AbilityEffectsTest {
 
         Dinosaur attacker = new Dinosaur(
                 "Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 1,
-                List.of(strike), null);
+                1, List.of(strike), null);
         Dinosaur armored = new Dinosaur(
                 "Armored", 100, 50, "assets/animals/allosaurus.png", 100, 10,
-                List.of(waitMove), new Ability("Armored", ""));
+                10, List.of(waitMove), new Ability("Armored", ""));
 
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(armored));
@@ -61,7 +61,7 @@ public class AbilityEffectsTest {
         Move cheer = new Move("Cheer", 0, 0, 0, List.of());
         Dinosaur helper = new Dinosaur(
                 "Helper", 100, 50, "assets/animals/allosaurus.png", 100, 10,
-                List.of(cheer), new Ability("Supporter", ""));
+                10, List.of(cheer), new Ability("Supporter", ""));
 
         int modified = AbilityEffects.modifyPriority(helper, cheer);
         assertEquals(1, modified);
@@ -78,10 +78,10 @@ public class AbilityEffectsTest {
 
         Dinosaur berserker = new Dinosaur(
                 "Berserker", 100, 50, "assets/animals/allosaurus.png", 100, 10,
-                List.of(strike), new Ability("Berserk", ""));
+                10, List.of(strike), new Ability("Berserk", ""));
         Dinosaur target = new Dinosaur(
                 "Target", 20, 50, "assets/animals/allosaurus.png", 100, 10,
-                List.of(waitMove), null);
+                10, List.of(waitMove), null);
 
         Player p1 = new Player(List.of(berserker));
         Player p2 = new Player(List.of(target));
@@ -99,10 +99,10 @@ public class AbilityEffectsTest {
 
         Dinosaur attacker = new Dinosaur(
                 "Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 1,
-                List.of(strike), null);
+                1, List.of(strike), null);
         Dinosaur tough = new Dinosaur(
                 "Tough", 100, 50, "assets/animals/allosaurus.png", 100, 10,
-                List.of(waitMove), new Ability("Tough", ""));
+                10, List.of(waitMove), new Ability("Tough", ""));
 
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(tough));
@@ -121,10 +121,10 @@ public class AbilityEffectsTest {
 
         Dinosaur attacker = new Dinosaur(
                 "Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 1,
-                List.of(strike), null);
+                1, List.of(strike), null);
         Dinosaur tough = new Dinosaur(
                 "Tough", 100, 50, "assets/animals/allosaurus.png", 100, 10,
-                List.of(waitMove), new Ability("Tough", ""));
+                10, List.of(waitMove), new Ability("Tough", ""));
 
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(tough));

--- a/src/test/java/com/mesozoic/arena/DinosaurTest.java
+++ b/src/test/java/com/mesozoic/arena/DinosaurTest.java
@@ -11,19 +11,21 @@ import java.util.List;
 public class DinosaurTest {
     @Test
     public void testStageAffectsStats() {
-        Dinosaur dino = new Dinosaur("Test", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(), null);
-        assertEquals(10, dino.getEffectiveAttack());
+        Dinosaur dino = new Dinosaur("Test", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(), null);
+        assertEquals(10, dino.getEffectiveHeadAttack());
+        assertEquals(10, dino.getEffectiveBodyAttack());
         assertEquals(50, dino.getEffectiveSpeed());
         dino.adjustAttackStage(1);
         dino.adjustSpeedStage(-1);
-        assertEquals(12.5, dino.getEffectiveAttack());
+        assertEquals(12.5, dino.getEffectiveHeadAttack());
+        assertEquals(12.5, dino.getEffectiveBodyAttack());
         assertEquals(40, dino.getEffectiveSpeed());
     }
 
     @Test
     public void testStagesResetOnBench() {
-        Dinosaur first = new Dinosaur("First", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(), null);
-        Dinosaur second = new Dinosaur("Second", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(), null);
+        Dinosaur first = new Dinosaur("First", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(), null);
+        Dinosaur second = new Dinosaur("Second", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(), null);
         Player player = new Player(List.of(first, second));
         first.adjustAttackStage(2);
         first.adjustSpeedStage(-2);
@@ -35,8 +37,8 @@ public class DinosaurTest {
     @Test
     public void testIntimidateLowersOpponentAttack() {
         Ability intimidate = new Ability("Intimidate", "");
-        Dinosaur intimidator = new Dinosaur("Intimidator", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(), intimidate);
-        Dinosaur target = new Dinosaur("Target", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(), null);
+        Dinosaur intimidator = new Dinosaur("Intimidator", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(), intimidate);
+        Dinosaur target = new Dinosaur("Target", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(), null);
         Player p1 = new Player(List.of(intimidator));
         Player p2 = new Player(List.of(target));
         new Battle(p1, p2); // ability triggers on battle start

--- a/src/test/java/com/mesozoic/arena/MoveEffectsTest.java
+++ b/src/test/java/com/mesozoic/arena/MoveEffectsTest.java
@@ -14,10 +14,10 @@ public class MoveEffectsTest {
     public void testAreaHealHealsWholeTeam() {
         Move areaHeal = new Move("Rally", 0, 0, 0, List.of(new Effect("area heal")));
         Move noop = new Move("Wait", 0, 0, 0, List.of());
-        Dinosaur active = new Dinosaur("Active", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(areaHeal), null);
-        Dinosaur bench = new Dinosaur("Bench", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null);
+        Dinosaur active = new Dinosaur("Active", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(areaHeal), null);
+        Dinosaur bench = new Dinosaur("Bench", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(noop), null);
         Player p1 = new Player(List.of(active, bench));
-        Player p2 = new Player(List.of(new Dinosaur("Opponent", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null)));
+        Player p2 = new Player(List.of(new Dinosaur("Opponent", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(noop), null)));
         Battle battle = new Battle(p1, p2);
 
         active.adjustHealth(-20);
@@ -32,10 +32,10 @@ public class MoveEffectsTest {
     public void testHealCapsAtMax() {
         Move heal = new Move("Recover", 0, 0, 0, List.of(new Effect("heal")));
         Move noop = new Move("Wait", 0, 0, 0, List.of());
-        Dinosaur active = new Dinosaur("Active", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(heal), null);
-        Dinosaur bench = new Dinosaur("Bench", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null);
+        Dinosaur active = new Dinosaur("Active", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(heal), null);
+        Dinosaur bench = new Dinosaur("Bench", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(noop), null);
         Player p1 = new Player(List.of(active, bench));
-        Player p2 = new Player(List.of(new Dinosaur("Opponent", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null)));
+        Player p2 = new Player(List.of(new Dinosaur("Opponent", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(noop), null)));
         Battle battle = new Battle(p1, p2);
 
         active.adjustHealth(-80); // 20 health left
@@ -54,8 +54,8 @@ public class MoveEffectsTest {
     public void testDoubleAttackHitsTwice() {
         Move doubleHit = new Move("Double", 1, 0, 0, List.of(new Effect("double attack")));
         Move noop = new Move("Wait", 0, 0, 0, List.of());
-        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(doubleHit), null);
-        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null);
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(doubleHit), null);
+        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(noop), null);
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(defender));
         Battle battle = new Battle(p1, p2);
@@ -68,8 +68,8 @@ public class MoveEffectsTest {
     public void testTripleAttackHitsThrice() {
         Move tripleHit = new Move("Triple", 1, 0, 0, List.of(new Effect("triple attack")));
         Move noop = new Move("Wait", 0, 0, 0, List.of());
-        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(tripleHit), null);
-        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null);
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(tripleHit), null);
+        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(noop), null);
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(defender));
         Battle battle = new Battle(p1, p2);
@@ -82,8 +82,8 @@ public class MoveEffectsTest {
     public void testFrenzyRaisesAttack() {
         Move frenzy = new Move("Rage", 0, 0, 0, List.of(new Effect("frenzy")));
         Move noop = new Move("Wait", 0, 0, 0, List.of());
-        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(frenzy), null);
-        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null);
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(frenzy), null);
+        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(noop), null);
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(defender));
         Battle battle = new Battle(p1, p2);
@@ -96,8 +96,8 @@ public class MoveEffectsTest {
     public void testAdrenalineRaisesAttackAndSpeed() {
         Move adrenaline = new Move("Boost", 0, 0, 0, List.of(new Effect("adrenaline")));
         Move noop = new Move("Wait", 0, 0, 0, List.of());
-        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(adrenaline), null);
-        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null);
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(adrenaline), null);
+        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(noop), null);
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(defender));
         Battle battle = new Battle(p1, p2);
@@ -111,8 +111,8 @@ public class MoveEffectsTest {
     public void testBleedDealsEndTurnDamage() {
         Move bleed = new Move("Cut", 0, 0, 0, List.of(new Effect("bleed")));
         Move noop = new Move("Wait", 0, 0, 0, List.of());
-        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(bleed), null);
-        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(noop), null);
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(bleed), null);
+        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(noop), null);
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(defender));
         Battle battle = new Battle(p1, p2);
@@ -126,8 +126,8 @@ public class MoveEffectsTest {
         Move bleed = new Move("Cut", 0, 0, 0, List.of(new Effect("bleed")));
         Move heal = new Move("Recover", 0, 0, 0, List.of(new Effect("heal")));
         Move noop = new Move("Wait", 0, 0, 0, List.of());
-        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(bleed), null);
-        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, List.of(heal), null);
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(bleed), null);
+        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 100, 10, 10, List.of(heal), null);
         defender.adjustHealth(-40);
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(defender));


### PR DESCRIPTION
## Summary
- add MoveType enum and move type parsing
- track head and body attack values for dinosaurs
- update battle logic and UI to use move type
- include move type and new attack stats in YAML data
- update tests for split attack stats

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6877ba0331c4832eb1bfefb1fc94858a