### PR TITLE
Add move accuracy system

### DIFF
--- a/data/moves.yaml
+++ b/data/moves.yaml
@@ -1,83 +1,95 @@
 Bite:
   damage: 40
+  accuracy: 0.9
   priority: 0
   effects: []
-  description: "Deal XX damage."
+  description: "Deal XX damage. YY accuracy."
   type: head
 
 Brace:
   damage: 0
+  accuracy: 0.9
   priority: 2
   effects: [brace]
-  description: "Prevent all damage dealt to you next turn. Fails if it was already used last turn. +2 Priority."
+  description: "Prevent all damage dealt to you next turn. Fails if it was already used last turn. +2 Priority. YY accuracy."
   type: body
 
 Charge:
   damage: 40
+  accuracy: 0.9
   priority: 1
   effects: []
-  description: "Deal XX damage. +1 Priority."
+  description: "Deal XX damage. +1 Priority. YY accuracy."
   type: body
 
 Double Scratch:
   damage: 18
+  accuracy: 0.9
   priority: 0
   effects: [double attack]
-  description: "Attack twice for XX damage each."
+  description: "Attack twice for XX damage each. YY accuracy."
   type: body
 
 Kick:
   damage: 30
+  accuracy: 0.9
   priority: 0
   effects: []
-  description: "Deal XX damage."
+  description: "Deal XX damage. YY accuracy."
   type: body
 
 Heal:
   damage: 0
+  accuracy: 0.9
   priority: 1
   effects: [heal]
-  description: "Recover 30 health. +1 Priority."
+  description: "Recover 30 health. +1 Priority. YY accuracy."
   type: body
 
 Impale:
   damage: 40
+  accuracy: 0.9
   priority: 0
   effects: []
-  description: "Deal XX damage."
+  description: "Deal XX damage. YY accuracy."
   type: head
 
 Roar:
   damage: 0
+  accuracy: 0.9
   priority: 0
   effects: []
-  description: "Rally your allies."
+  description: "Rally your allies. YY accuracy."
   type: head
 
 Scratch:
   damage: 20
+  accuracy: 0.9
   priority: 0
   effects: []
-  description: "Deal XX damage."
+  description: "Deal XX damage. YY accuracy."
   type: body
 
 Tail Swipe:
   damage: 30
+  accuracy: 0.9
   priority: 0
   effects: []
-  description: "Deal XX damage."
+  description: "Deal XX damage. YY accuracy."
   type: body
 
 Thagomizer Swipe:
   damage: 40
+  accuracy: 0.9
   priority: 0
   effects: []
-  description: "Deal XX damage."
+  description: "Deal XX damage. YY accuracy."
   type: body
 
 Stomp:
   damage: 22
+  accuracy: 0.9
   priority: 0
   effects: []
-  description: "Deal XX damage."
+  description: "Deal XX damage. YY accuracy."
   type: body

--- a/src/main/java/com/mesozoic/arena/data/DinosaurLoader.java
+++ b/src/main/java/com/mesozoic/arena/data/DinosaurLoader.java
@@ -108,8 +108,9 @@ public class DinosaurLoader {
                 Move template = moveTemplates.get(moveName);
                 if (template != null) {
                     moves.add(new Move(template.getName(), template.getDamage(),
-                            template.getPriority(),
-                            template.getDescription(), template.getEffects()));
+                            template.getPriority(), template.getDescription(),
+                            template.getType(), template.getEffects(),
+                            template.getAccuracy()));
                 }
             }
         }
@@ -141,7 +142,8 @@ public class DinosaurLoader {
         for (Move move : source.getMoves()) {
             copiedMoves.add(new Move(move.getName(), move.getDamage(),
                     move.getPriority(),
-                    move.getDescription(), move.getEffects()));
+                    move.getDescription(), move.getType(),
+                    move.getEffects(), move.getAccuracy()));
         }
         return new Dinosaur(source.getName(), source.getHealth(), source.getSpeed(), source.getImagePath(),
                 source.getHeadAttack(), source.getBodyAttack(), copiedMoves, source.getAbility());
@@ -163,8 +165,9 @@ public class DinosaurLoader {
                     String description = String.valueOf(values.getOrDefault("description", ""));
                     String typeLabel = String.valueOf(values.getOrDefault("type", "body"));
                     MoveType type = "head".equalsIgnoreCase(typeLabel) ? MoveType.HEAD : MoveType.BODY;
+                    double accuracy = ((Number) values.getOrDefault("accuracy", 1.0)).doubleValue();
                     List<Effect> effects = parseEffects(values.get("effects"));
-                    map.put(name, new Move(name, damage, priority, description, type, effects));
+                    map.put(name, new Move(name, damage, priority, description, type, effects, accuracy));
                 }
             }
         }

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -31,6 +31,15 @@ public class Battle {
     private int turn = 1;
     private Player winner;
 
+    private boolean moveHits(Move move) {
+        return move != null && Math.random() < move.getAccuracy();
+    }
+
+    private void logMiss(Player actingPlayer, Dinosaur attacker, Move move) {
+        String actorLabel = actingPlayer == playerOne ? "Player " : "NPC ";
+        addEvent(actorLabel + attacker.getName() + " used " + move.getName() + " but missed.");
+    }
+
     public Battle(Player playerOne, Player playerTwo) {
         this(playerOne, playerTwo, createAgent());
     }
@@ -192,6 +201,12 @@ public class Battle {
             Dinosaur defender = opposingPlayer.getActiveDinosaur();
             if (attacker == null || defender == null || move == null) {
                 return defenderFainted;
+            }
+
+            if (!moveHits(move)) {
+                logMiss(actingPlayer, attacker, move);
+                defenderBraced = false;
+                continue;
             }
 
             applyMoveEffects(actingPlayer, opposingPlayer, move);

--- a/src/main/java/com/mesozoic/arena/model/Move.java
+++ b/src/main/java/com/mesozoic/arena/model/Move.java
@@ -13,16 +13,22 @@ public class Move {
     private final List<Effect> effects;
     private final String description;
     private final MoveType type;
+    private final double accuracy;
 
     public Move(String name, int damage, int priority, List<Effect> effects) {
-        this(name, damage, priority, "", MoveType.BODY, effects);
+        this(name, damage, priority, "", MoveType.BODY, effects, 1.0);
     }
 
     public Move(String name, int damage, int priority, String description, List<Effect> effects) {
-        this(name, damage, priority, description, MoveType.BODY, effects);
+        this(name, damage, priority, description, MoveType.BODY, effects, 1.0);
     }
 
     public Move(String name, int damage, int priority, String description, MoveType type, List<Effect> effects) {
+        this(name, damage, priority, description, type, effects, 1.0);
+    }
+
+    public Move(String name, int damage, int priority, String description, MoveType type,
+            List<Effect> effects, double accuracy) {
         this.name = name;
         this.damage = damage;
         this.priority = priority;
@@ -33,6 +39,7 @@ public class Move {
         }
         this.description = description == null ? "" : description;
         this.type = type == null ? MoveType.BODY : type;
+        this.accuracy = accuracy;
     }
 
     public String getName() {
@@ -59,11 +66,16 @@ public class Move {
         return type;
     }
 
+    public double getAccuracy() {
+        return accuracy;
+    }
+
     public String getDescriptionWithDamage(Dinosaur user) {
         double attackValue = type == MoveType.HEAD
                 ? user.getEffectiveHeadAttack()
                 : user.getEffectiveBodyAttack();
         long realDamage = Math.round(damage * attackValue);
-        return description.replace("XX", String.valueOf(realDamage));
+        String withDamage = description.replace("XX", String.valueOf(realDamage));
+        return withDamage.replace("YY", String.valueOf(accuracy));
     }
 }

--- a/src/main/java/com/mesozoic/arena/util/DinosaurLoader.java
+++ b/src/main/java/com/mesozoic/arena/util/DinosaurLoader.java
@@ -39,8 +39,10 @@ public final class DinosaurLoader {
                 Map<String, Object> val = castMap(entry.getValue());
                 int damage = toInt(val.get("damage"));
                 int priority = toInt(val.getOrDefault("priority", 0));
+                String description = String.valueOf(val.getOrDefault("description", ""));
                 String typeLabel = String.valueOf(val.getOrDefault("type", "body"));
                 MoveType type = "head".equalsIgnoreCase(typeLabel) ? MoveType.HEAD : MoveType.BODY;
+                double accuracy = Double.parseDouble(String.valueOf(val.getOrDefault("accuracy", 1.0)));
                 List<Effect> effects = new ArrayList<>();
                 List<?> eff = castObjectList(val.get("effects"));
                 if (eff != null) {
@@ -50,7 +52,7 @@ public final class DinosaurLoader {
                         }
                     }
                 }
-                moves.put(name, new Move(name, damage, priority, "", type, effects));
+                moves.put(name, new Move(name, damage, priority, description, type, effects, accuracy));
             }
 
             Map<String, Object> data = yaml.load(dinoStream);
@@ -72,7 +74,7 @@ public final class DinosaurLoader {
                         if (m != null) {
                             dinoMoves.add(new Move(m.getName(), m.getDamage(),
                                     m.getPriority(), m.getDescription(), m.getType(),
-                                    m.getEffects()));
+                                    m.getEffects(), m.getAccuracy()));
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- introduce `accuracy` field to `Move` class and update descriptions to show accuracy value
- load move accuracy from YAML
- add hit/miss logic to `Battle` using new field
- provide accuracy info in YAML descriptions

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68780da3adf0832e80e71624a2f3b448