### PR TITLE
Rename move type attribute to kind

### DIFF
--- a/data/moves.yaml
+++ b/data/moves.yaml
@@ -4,7 +4,7 @@ Bite:
   priority: 0
   effects: []
   description: "Deal XX damage. YY accuracy."
-  type: head
+  kind: head
 
 Brace:
   damage: 0
@@ -12,7 +12,7 @@ Brace:
   priority: 2
   effects: [brace]
   description: "Prevent all damage dealt to you next turn. Fails if it was already used last turn. +2 Priority. YY accuracy."
-  type: body
+  kind: body
 
 Charge:
   damage: 40
@@ -20,7 +20,7 @@ Charge:
   priority: 1
   effects: []
   description: "Deal XX damage. +1 Priority. YY accuracy."
-  type: body
+  kind: body
 
 Double Scratch:
   damage: 18
@@ -28,7 +28,7 @@ Double Scratch:
   priority: 0
   effects: [double attack]
   description: "Attack twice for XX damage each. YY accuracy."
-  type: body
+  kind: body
 
 Kick:
   damage: 30
@@ -36,7 +36,7 @@ Kick:
   priority: 0
   effects: []
   description: "Deal XX damage. YY accuracy."
-  type: body
+  kind: body
 
 Heal:
   damage: 0
@@ -44,7 +44,7 @@ Heal:
   priority: 1
   effects: [heal]
   description: "Recover 30 health. +1 Priority. YY accuracy."
-  type: body
+  kind: body
 
 Impale:
   damage: 40
@@ -52,7 +52,7 @@ Impale:
   priority: 0
   effects: []
   description: "Deal XX damage. YY accuracy."
-  type: head
+  kind: head
 
 Roar:
   damage: 0
@@ -60,7 +60,7 @@ Roar:
   priority: 0
   effects: []
   description: "Rally your allies. YY accuracy."
-  type: head
+  kind: head
 
 Scratch:
   damage: 20
@@ -68,7 +68,7 @@ Scratch:
   priority: 0
   effects: []
   description: "Deal XX damage. YY accuracy."
-  type: body
+  kind: body
 
 Tail Swipe:
   damage: 30
@@ -76,7 +76,7 @@ Tail Swipe:
   priority: 0
   effects: []
   description: "Deal XX damage. YY accuracy."
-  type: body
+  kind: body
 
 Thagomizer Swipe:
   damage: 40
@@ -84,7 +84,7 @@ Thagomizer Swipe:
   priority: 0
   effects: []
   description: "Deal XX damage. YY accuracy."
-  type: body
+  kind: body
 
 Stomp:
   damage: 22
@@ -92,4 +92,4 @@ Stomp:
   priority: 0
   effects: []
   description: "Deal XX damage. YY accuracy."
-  type: body
+  kind: body

--- a/src/main/java/com/mesozoic/arena/data/DinosaurLoader.java
+++ b/src/main/java/com/mesozoic/arena/data/DinosaurLoader.java
@@ -109,7 +109,7 @@ public class DinosaurLoader {
                 if (template != null) {
                     moves.add(new Move(template.getName(), template.getDamage(),
                             template.getPriority(), template.getDescription(),
-                            template.getType(), template.getEffects(),
+                            template.getKind(), template.getEffects(),
                             template.getAccuracy()));
                 }
             }
@@ -142,7 +142,7 @@ public class DinosaurLoader {
         for (Move move : source.getMoves()) {
             copiedMoves.add(new Move(move.getName(), move.getDamage(),
                     move.getPriority(),
-                    move.getDescription(), move.getType(),
+                    move.getDescription(), move.getKind(),
                     move.getEffects(), move.getAccuracy()));
         }
         return new Dinosaur(source.getName(), source.getHealth(), source.getSpeed(), source.getImagePath(),
@@ -163,11 +163,11 @@ public class DinosaurLoader {
                     int damage = ((Number) values.getOrDefault("damage", 0)).intValue();
                     int priority = ((Number) values.getOrDefault("priority", 0)).intValue();
                     String description = String.valueOf(values.getOrDefault("description", ""));
-                    String typeLabel = String.valueOf(values.getOrDefault("type", "body"));
-                    MoveType type = "head".equalsIgnoreCase(typeLabel) ? MoveType.HEAD : MoveType.BODY;
+                    String kindLabel = String.valueOf(values.getOrDefault("kind", "body"));
+                    MoveType kind = "head".equalsIgnoreCase(kindLabel) ? MoveType.HEAD : MoveType.BODY;
                     double accuracy = ((Number) values.getOrDefault("accuracy", 1.0)).doubleValue();
                     List<Effect> effects = parseEffects(values.get("effects"));
-                    map.put(name, new Move(name, damage, priority, description, type, effects, accuracy));
+                    map.put(name, new Move(name, damage, priority, description, kind, effects, accuracy));
                 }
             }
         }

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -211,7 +211,7 @@ public class Battle {
 
             applyMoveEffects(actingPlayer, opposingPlayer, move);
             if (!defenderBraced) {
-                double attackValue = move.getType() == MoveType.HEAD
+                double attackValue = move.getKind() == MoveType.HEAD
                         ? attacker.getEffectiveHeadAttack()
                         : attacker.getEffectiveBodyAttack();
                 int totalDamage = Math.toIntExact(Math.round(move.getDamage() * attackValue));

--- a/src/main/java/com/mesozoic/arena/model/Move.java
+++ b/src/main/java/com/mesozoic/arena/model/Move.java
@@ -12,7 +12,7 @@ public class Move {
     private final int priority;
     private final List<Effect> effects;
     private final String description;
-    private final MoveType type;
+    private final MoveType kind;
     private final double accuracy;
 
     public Move(String name, int damage, int priority, List<Effect> effects) {
@@ -23,11 +23,11 @@ public class Move {
         this(name, damage, priority, description, MoveType.BODY, effects, 1.0);
     }
 
-    public Move(String name, int damage, int priority, String description, MoveType type, List<Effect> effects) {
-        this(name, damage, priority, description, type, effects, 1.0);
+    public Move(String name, int damage, int priority, String description, MoveType kind, List<Effect> effects) {
+        this(name, damage, priority, description, kind, effects, 1.0);
     }
 
-    public Move(String name, int damage, int priority, String description, MoveType type,
+    public Move(String name, int damage, int priority, String description, MoveType kind,
             List<Effect> effects, double accuracy) {
         this.name = name;
         this.damage = damage;
@@ -38,7 +38,7 @@ public class Move {
             this.effects = new ArrayList<>(effects);
         }
         this.description = description == null ? "" : description;
-        this.type = type == null ? MoveType.BODY : type;
+        this.kind = kind == null ? MoveType.BODY : kind;
         this.accuracy = accuracy;
     }
 
@@ -62,8 +62,8 @@ public class Move {
         return description;
     }
 
-    public MoveType getType() {
-        return type;
+    public MoveType getKind() {
+        return kind;
     }
 
     public double getAccuracy() {
@@ -71,7 +71,7 @@ public class Move {
     }
 
     public String getDescriptionWithDamage(Dinosaur user) {
-        double attackValue = type == MoveType.HEAD
+        double attackValue = kind == MoveType.HEAD
                 ? user.getEffectiveHeadAttack()
                 : user.getEffectiveBodyAttack();
         long realDamage = Math.round(damage * attackValue);

--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -238,7 +238,7 @@ public class MainWindow extends JFrame {
     }
 
     private JButton createMoveButton(Dinosaur dino, Move move, boolean playerSide) {
-        double attackValue = move.getType() == MoveType.HEAD
+        double attackValue = move.getKind() == MoveType.HEAD
                 ? dino.getEffectiveHeadAttack()
                 : dino.getEffectiveBodyAttack();
         int damage = Math.toIntExact(Math.round(move.getDamage() * attackValue));

--- a/src/main/java/com/mesozoic/arena/util/DinosaurLoader.java
+++ b/src/main/java/com/mesozoic/arena/util/DinosaurLoader.java
@@ -40,8 +40,8 @@ public final class DinosaurLoader {
                 int damage = toInt(val.get("damage"));
                 int priority = toInt(val.getOrDefault("priority", 0));
                 String description = String.valueOf(val.getOrDefault("description", ""));
-                String typeLabel = String.valueOf(val.getOrDefault("type", "body"));
-                MoveType type = "head".equalsIgnoreCase(typeLabel) ? MoveType.HEAD : MoveType.BODY;
+                String kindLabel = String.valueOf(val.getOrDefault("kind", "body"));
+                MoveType kind = "head".equalsIgnoreCase(kindLabel) ? MoveType.HEAD : MoveType.BODY;
                 double accuracy = Double.parseDouble(String.valueOf(val.getOrDefault("accuracy", 1.0)));
                 List<Effect> effects = new ArrayList<>();
                 List<?> eff = castObjectList(val.get("effects"));
@@ -52,7 +52,7 @@ public final class DinosaurLoader {
                         }
                     }
                 }
-                moves.put(name, new Move(name, damage, priority, description, type, effects, accuracy));
+                moves.put(name, new Move(name, damage, priority, description, kind, effects, accuracy));
             }
 
             Map<String, Object> data = yaml.load(dinoStream);
@@ -73,7 +73,7 @@ public final class DinosaurLoader {
                         Move m = moves.get(String.valueOf(n));
                         if (m != null) {
                             dinoMoves.add(new Move(m.getName(), m.getDamage(),
-                                    m.getPriority(), m.getDescription(), m.getType(),
+                                    m.getPriority(), m.getDescription(), m.getKind(),
                                     m.getEffects(), m.getAccuracy()));
                         }
                     }


### PR DESCRIPTION
## Summary
- rename `Move` attribute `type` to `kind`
- update YAML and loader code to use `kind`
- adjust callers in engine and UI

## Testing
- `mvn test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_68790855d3c4832eafa94eed98a9bbda