### PR TITLE
Add battle type system

### DIFF
--- a/data/animals.yaml
+++ b/data/animals.yaml
@@ -1,4 +1,5 @@
 Allosaurus:
+  types: [Biter]
   health: 140
   speed: 100
   head attack: 1.1
@@ -12,6 +13,7 @@ Allosaurus:
     - Tail Swipe
 
 Ceratosaurus:
+  types: [Biter]
   health: 110
   speed: 110
   head attack: 0.99
@@ -25,6 +27,7 @@ Ceratosaurus:
     - Tail Swipe
 
 Corythosaurus:
+  types: [Biter]
   health: 140
   speed: 95
   head attack: 0.62
@@ -38,6 +41,7 @@ Corythosaurus:
     - Tail Swipe
 
 Daspletosaurus:
+  types: [Biter]
   health: 140
   speed: 90
   head attack: 1.2
@@ -51,6 +55,7 @@ Daspletosaurus:
     - Tail Swipe
 
 Stegosaurus:
+  types: [Biter]
   health: 160
   speed: 60
   head attack: 0.65
@@ -64,6 +69,7 @@ Stegosaurus:
     - Thagomizer Swipe
 
 Styracosaurus:
+  types: [Biter]
   health: 90
   speed: 75
   head attack: 0.86

--- a/data/moves.yaml
+++ b/data/moves.yaml
@@ -1,4 +1,5 @@
 Bite:
+  type: Biter
   damage: 40
   accuracy: 0.9
   priority: 0
@@ -7,6 +8,7 @@ Bite:
   kind: head
 
 Brace:
+  type: Biter
   damage: 0
   accuracy: 0.9
   priority: 2
@@ -15,6 +17,7 @@ Brace:
   kind: body
 
 Charge:
+  type: Biter
   damage: 40
   accuracy: 0.9
   priority: 1
@@ -23,6 +26,7 @@ Charge:
   kind: body
 
 Double Scratch:
+  type: Biter
   damage: 18
   accuracy: 0.9
   priority: 0
@@ -31,6 +35,7 @@ Double Scratch:
   kind: body
 
 Kick:
+  type: Biter
   damage: 30
   accuracy: 0.9
   priority: 0
@@ -39,6 +44,7 @@ Kick:
   kind: body
 
 Heal:
+  type: Biter
   damage: 0
   accuracy: 0.9
   priority: 1
@@ -47,6 +53,7 @@ Heal:
   kind: body
 
 Impale:
+  type: Biter
   damage: 40
   accuracy: 0.9
   priority: 0
@@ -55,6 +62,7 @@ Impale:
   kind: head
 
 Roar:
+  type: Biter
   damage: 0
   accuracy: 0.9
   priority: 0
@@ -63,6 +71,7 @@ Roar:
   kind: head
 
 Scratch:
+  type: Biter
   damage: 20
   accuracy: 0.9
   priority: 0
@@ -71,6 +80,7 @@ Scratch:
   kind: body
 
 Tail Swipe:
+  type: Biter
   damage: 30
   accuracy: 0.9
   priority: 0
@@ -79,6 +89,7 @@ Tail Swipe:
   kind: body
 
 Thagomizer Swipe:
+  type: Biter
   damage: 40
   accuracy: 0.9
   priority: 0
@@ -87,6 +98,7 @@ Thagomizer Swipe:
   kind: body
 
 Stomp:
+  type: Biter
   damage: 22
   accuracy: 0.9
   priority: 0

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -214,7 +214,8 @@ public class Battle {
                 double attackValue = move.getKind() == MoveType.HEAD
                         ? attacker.getEffectiveHeadAttack()
                         : attacker.getEffectiveBodyAttack();
-                int totalDamage = Math.toIntExact(Math.round(move.getDamage() * attackValue));
+                double typeMultiplier = defender.getMultiplierFrom(move.getType());
+                int totalDamage = Math.toIntExact(Math.round(move.getDamage() * attackValue * typeMultiplier));
                 totalDamage = AbilityEffects.modifyIncomingDamage(defender, totalDamage);
                 int beforeHealth = defender.getHealth();
                 defender.adjustHealth(-totalDamage);

--- a/src/main/java/com/mesozoic/arena/model/DinoType.java
+++ b/src/main/java/com/mesozoic/arena/model/DinoType.java
@@ -1,0 +1,89 @@
+package com.mesozoic.arena.model;
+
+import java.util.EnumSet;
+
+/**
+ * Represents the elemental typing for dinosaurs and moves.
+ */
+public enum DinoType {
+    BITER,
+    BLEEDER,
+    CHARGER,
+    CRUSHER,
+    DEFENDER,
+    GRAZER,
+    IMPALER,
+    LANDSCAPER,
+    RUNNER,
+    SLASHER,
+    SWIMMER;
+
+    private EnumSet<DinoType> weakTo;
+    private EnumSet<DinoType> resistantTo;
+
+    static {
+        BITER.weakTo = EnumSet.of(CRUSHER, IMPALER);
+        BITER.resistantTo = EnumSet.of(BITER, SLASHER);
+
+        BLEEDER.weakTo = EnumSet.of(CRUSHER, RUNNER);
+        BLEEDER.resistantTo = EnumSet.of(BLEEDER, LANDSCAPER);
+
+        CHARGER.weakTo = EnumSet.of(SLASHER, GRAZER);
+        CHARGER.resistantTo = EnumSet.of(CHARGER, CRUSHER, BLEEDER, SWIMMER);
+
+        CRUSHER.weakTo = EnumSet.of(SLASHER, CHARGER);
+        CRUSHER.resistantTo = EnumSet.of(DEFENDER, GRAZER, IMPALER);
+
+        DEFENDER.weakTo = EnumSet.of(CRUSHER, LANDSCAPER);
+        DEFENDER.resistantTo = EnumSet.of(BITER, BLEEDER, DEFENDER, GRAZER, SLASHER, SWIMMER);
+
+        GRAZER.weakTo = EnumSet.of(BITER, BLEEDER, CRUSHER, SLASHER);
+        GRAZER.resistantTo = EnumSet.of(DEFENDER, GRAZER);
+
+        IMPALER.weakTo = EnumSet.of(DEFENDER, RUNNER);
+        IMPALER.resistantTo = EnumSet.of(BLEEDER, CHARGER, IMPALER);
+
+        LANDSCAPER.weakTo = EnumSet.of(BLEEDER);
+        LANDSCAPER.resistantTo = EnumSet.of(CRUSHER, LANDSCAPER);
+
+        RUNNER.weakTo = EnumSet.of(BITER, GRAZER, SWIMMER);
+        RUNNER.resistantTo = EnumSet.of(RUNNER, LANDSCAPER);
+
+        SLASHER.weakTo = EnumSet.of(CHARGER, DEFENDER);
+        SLASHER.resistantTo = EnumSet.of(LANDSCAPER, SLASHER);
+
+        SWIMMER.weakTo = EnumSet.of(BLEEDER);
+        SWIMMER.resistantTo = EnumSet.of(DEFENDER, SWIMMER);
+    }
+
+    /**
+     * Returns the damage multiplier when attacked by the given type.
+     */
+    public double getMultiplierFrom(DinoType attackType) {
+        if (attackType == null) {
+            return 1.0;
+        }
+        if (weakTo.contains(attackType)) {
+            return 2.0;
+        }
+        if (resistantTo.contains(attackType)) {
+            return 0.5;
+        }
+        return 1.0;
+    }
+
+    /**
+     * Parses a type label, returning BITER if the value is invalid.
+     */
+    public static DinoType fromString(String label) {
+        if (label == null) {
+            return BITER;
+        }
+        for (DinoType type : values()) {
+            if (type.name().equalsIgnoreCase(label)) {
+                return type;
+            }
+        }
+        return BITER;
+    }
+}

--- a/src/main/java/com/mesozoic/arena/model/Dinosaur.java
+++ b/src/main/java/com/mesozoic/arena/model/Dinosaur.java
@@ -18,10 +18,18 @@ public class Dinosaur {
     private final double bodyAttack;
     private int attackStage = 0;
     private final List<Move> moves;
+    private final List<DinoType> types;
     private final List<Ailment> ailments = new ArrayList<>();
 
     public Dinosaur(String name, int health, int speed, String imagePath,
                     double headAttack, double bodyAttack, List<Move> moves, Ability ability) {
+        this(name, health, speed, imagePath, headAttack, bodyAttack, moves, ability,
+                List.of(DinoType.BITER));
+    }
+
+    public Dinosaur(String name, int health, int speed, String imagePath,
+                    double headAttack, double bodyAttack, List<Move> moves,
+                    Ability ability, List<DinoType> types) {
         this.name = name;
         this.health = health;
         this.maxHealth = health;
@@ -34,6 +42,11 @@ public class Dinosaur {
             this.moves = new ArrayList<>();
         } else {
             this.moves = new ArrayList<>(moves);
+        }
+        if (types == null || types.isEmpty()) {
+            this.types = new ArrayList<>(List.of(DinoType.BITER));
+        } else {
+            this.types = new ArrayList<>(types);
         }
     }
 
@@ -73,6 +86,18 @@ public class Dinosaur {
 
     public List<Move> getMoves() {
         return new ArrayList<>(moves);
+    }
+
+    public List<DinoType> getTypes() {
+        return new ArrayList<>(types);
+    }
+
+    public double getMultiplierFrom(DinoType attackType) {
+        double multiplier = 1.0;
+        for (DinoType type : types) {
+            multiplier *= type.getMultiplierFrom(attackType);
+        }
+        return multiplier;
     }
 
     public List<Ailment> getAilments() {

--- a/src/main/java/com/mesozoic/arena/model/Move.java
+++ b/src/main/java/com/mesozoic/arena/model/Move.java
@@ -13,22 +13,23 @@ public class Move {
     private final List<Effect> effects;
     private final String description;
     private final MoveType kind;
+    private final DinoType type;
     private final double accuracy;
 
     public Move(String name, int damage, int priority, List<Effect> effects) {
-        this(name, damage, priority, "", MoveType.BODY, effects, 1.0);
+        this(name, damage, priority, "", MoveType.BODY, DinoType.BITER, effects, 1.0);
     }
 
     public Move(String name, int damage, int priority, String description, List<Effect> effects) {
-        this(name, damage, priority, description, MoveType.BODY, effects, 1.0);
+        this(name, damage, priority, description, MoveType.BODY, DinoType.BITER, effects, 1.0);
     }
 
     public Move(String name, int damage, int priority, String description, MoveType kind, List<Effect> effects) {
-        this(name, damage, priority, description, kind, effects, 1.0);
+        this(name, damage, priority, description, kind, DinoType.BITER, effects, 1.0);
     }
 
     public Move(String name, int damage, int priority, String description, MoveType kind,
-            List<Effect> effects, double accuracy) {
+            DinoType type, List<Effect> effects, double accuracy) {
         this.name = name;
         this.damage = damage;
         this.priority = priority;
@@ -39,7 +40,12 @@ public class Move {
         }
         this.description = description == null ? "" : description;
         this.kind = kind == null ? MoveType.BODY : kind;
+        this.type = type == null ? DinoType.BITER : type;
         this.accuracy = accuracy;
+    }
+
+    public DinoType getType() {
+        return type;
     }
 
     public String getName() {

--- a/src/main/java/com/mesozoic/arena/util/DinosaurLoader.java
+++ b/src/main/java/com/mesozoic/arena/util/DinosaurLoader.java
@@ -4,6 +4,7 @@ import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Effect;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.MoveType;
+import com.mesozoic.arena.model.DinoType;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,6 +43,7 @@ public final class DinosaurLoader {
                 String description = String.valueOf(val.getOrDefault("description", ""));
                 String kindLabel = String.valueOf(val.getOrDefault("kind", "body"));
                 MoveType kind = "head".equalsIgnoreCase(kindLabel) ? MoveType.HEAD : MoveType.BODY;
+                DinoType type = DinoType.fromString(String.valueOf(val.getOrDefault("type", "Biter")));
                 double accuracy = Double.parseDouble(String.valueOf(val.getOrDefault("accuracy", 1.0)));
                 List<Effect> effects = new ArrayList<>();
                 List<?> eff = castObjectList(val.get("effects"));
@@ -52,7 +54,7 @@ public final class DinosaurLoader {
                         }
                     }
                 }
-                moves.put(name, new Move(name, damage, priority, description, kind, effects, accuracy));
+                moves.put(name, new Move(name, damage, priority, description, kind, type, effects, accuracy));
             }
 
             Map<String, Object> data = yaml.load(dinoStream);
@@ -73,13 +75,24 @@ public final class DinosaurLoader {
                         Move m = moves.get(String.valueOf(n));
                         if (m != null) {
                             dinoMoves.add(new Move(m.getName(), m.getDamage(),
-                                    m.getPriority(), m.getDescription(), m.getKind(),
+                                    m.getPriority(), m.getDescription(), m.getKind(), m.getType(),
                                     m.getEffects(), m.getAccuracy()));
                         }
                     }
                 }
+
+                List<DinoType> types = new ArrayList<>();
+                Object rawTypes = dinoData.get("types");
+                if (rawTypes instanceof List<?> list) {
+                    for (Object obj : list) {
+                        types.add(DinoType.fromString(String.valueOf(obj)));
+                    }
+                } else if (rawTypes != null) {
+                    types.add(DinoType.fromString(String.valueOf(rawTypes)));
+                }
+
                 dinosaurs.add(new Dinosaur(name, health, speed, image, headAttack, bodyAttack,
-                        dinoMoves, null));
+                        dinoMoves, null, types));
             }
             return dinosaurs;
         } catch (Exception e) {

--- a/src/test/java/com/mesozoic/arena/AbilityEffectsTest.java
+++ b/src/test/java/com/mesozoic/arena/AbilityEffectsTest.java
@@ -31,7 +31,7 @@ public class AbilityEffectsTest {
         battle.executeRound(strike, waitMove);
 
         assertEquals(90, attacker.getHealth());
-        assertEquals(95, spiky.getHealth());
+        assertEquals(97, spiky.getHealth());
     }
 
     @Test
@@ -53,7 +53,7 @@ public class AbilityEffectsTest {
         battle.executeRound(strike, waitMove);
 
         assertEquals(100, attacker.getHealth());
-        assertEquals(95, armored.getHealth());
+        assertEquals(100, armored.getHealth());
     }
 
     @Test
@@ -111,7 +111,7 @@ public class AbilityEffectsTest {
         battle.executeRound(strike, waitMove);
 
         assertEquals(100, attacker.getHealth());
-        assertEquals(90, tough.getHealth());
+        assertEquals(95, tough.getHealth());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class AbilityEffectsTest {
         battle.executeRound(strike, waitMove);
 
         assertEquals(100, attacker.getHealth());
-        assertEquals(60, tough.getHealth());
+        assertEquals(75, tough.getHealth());
     }
 }
 

--- a/src/test/java/com/mesozoic/arena/MoveEffectsTest.java
+++ b/src/test/java/com/mesozoic/arena/MoveEffectsTest.java
@@ -61,7 +61,7 @@ public class MoveEffectsTest {
         Battle battle = new Battle(p1, p2);
 
         battle.executeRound(doubleHit, noop);
-        assertEquals(80, defender.getHealth());
+        assertEquals(90, defender.getHealth());
     }
 
     @Test
@@ -75,7 +75,7 @@ public class MoveEffectsTest {
         Battle battle = new Battle(p1, p2);
 
         battle.executeRound(tripleHit, noop);
-        assertEquals(70, defender.getHealth());
+        assertEquals(85, defender.getHealth());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- introduce `DinoType` enum defining weaknesses and resistances
- extend `Move` and `Dinosaur` with typing information
- apply type effectiveness in battle damage calculations
- parse new `type` fields from YAML files
- update tests for new damage values
- assign `Biter` type to all animals and moves by default

## Testing
- `mvn test -DtrimStackTrace=false`

------
https://chatgpt.com/codex/tasks/task_e_68791e59d000832e8df8a6b6d32d9e19