### PR TITLE
Add STAB damage bonus

### DIFF
--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -214,8 +214,9 @@ public class Battle {
                 double attackValue = move.getKind() == MoveType.HEAD
                         ? attacker.getEffectiveHeadAttack()
                         : attacker.getEffectiveBodyAttack();
+                double stab = attacker.hasType(move.getType()) ? 1.5 : 1.0;
                 double typeMultiplier = defender.getMultiplierFrom(move.getType());
-                int totalDamage = Math.toIntExact(Math.round(move.getDamage() * attackValue * typeMultiplier));
+                int totalDamage = Math.toIntExact(Math.round(move.getDamage() * attackValue * stab * typeMultiplier));
                 totalDamage = AbilityEffects.modifyIncomingDamage(defender, totalDamage);
                 int beforeHealth = defender.getHealth();
                 defender.adjustHealth(-totalDamage);

--- a/src/main/java/com/mesozoic/arena/model/Dinosaur.java
+++ b/src/main/java/com/mesozoic/arena/model/Dinosaur.java
@@ -92,6 +92,24 @@ public class Dinosaur {
         return new ArrayList<>(types);
     }
 
+    /**
+     * Checks if this dinosaur has the specified type.
+     *
+     * @param searchType the type to look for
+     * @return {@code true} if the dinosaur has the type, otherwise {@code false}
+     */
+    public boolean hasType(DinoType searchType) {
+        if (searchType == null) {
+            return false;
+        }
+        for (DinoType currentType : types) {
+            if (currentType == searchType) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public double getMultiplierFrom(DinoType attackType) {
         double multiplier = 1.0;
         for (DinoType type : types) {

--- a/src/test/java/com/mesozoic/arena/AbilityEffectsTest.java
+++ b/src/test/java/com/mesozoic/arena/AbilityEffectsTest.java
@@ -31,7 +31,7 @@ public class AbilityEffectsTest {
         battle.executeRound(strike, waitMove);
 
         assertEquals(90, attacker.getHealth());
-        assertEquals(97, spiky.getHealth());
+        assertEquals(96, spiky.getHealth());
     }
 
     @Test
@@ -53,7 +53,7 @@ public class AbilityEffectsTest {
         battle.executeRound(strike, waitMove);
 
         assertEquals(100, attacker.getHealth());
-        assertEquals(100, armored.getHealth());
+        assertEquals(99, armored.getHealth());
     }
 
     @Test
@@ -111,7 +111,7 @@ public class AbilityEffectsTest {
         battle.executeRound(strike, waitMove);
 
         assertEquals(100, attacker.getHealth());
-        assertEquals(95, tough.getHealth());
+        assertEquals(92, tough.getHealth());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class AbilityEffectsTest {
         battle.executeRound(strike, waitMove);
 
         assertEquals(100, attacker.getHealth());
-        assertEquals(75, tough.getHealth());
+        assertEquals(67, tough.getHealth());
     }
 }
 

--- a/src/test/java/com/mesozoic/arena/MoveEffectsTest.java
+++ b/src/test/java/com/mesozoic/arena/MoveEffectsTest.java
@@ -61,7 +61,7 @@ public class MoveEffectsTest {
         Battle battle = new Battle(p1, p2);
 
         battle.executeRound(doubleHit, noop);
-        assertEquals(90, defender.getHealth());
+        assertEquals(84, defender.getHealth());
     }
 
     @Test
@@ -75,7 +75,7 @@ public class MoveEffectsTest {
         Battle battle = new Battle(p1, p2);
 
         battle.executeRound(tripleHit, noop);
-        assertEquals(85, defender.getHealth());
+        assertEquals(76, defender.getHealth());
     }
 
     @Test

--- a/src/test/java/com/mesozoic/arena/TypeBonusTest.java
+++ b/src/test/java/com/mesozoic/arena/TypeBonusTest.java
@@ -1,0 +1,51 @@
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.Player;
+import com.mesozoic.arena.model.MoveType;
+import com.mesozoic.arena.model.DinoType;
+import com.mesozoic.arena.engine.Battle;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+public class TypeBonusTest {
+    @Test
+    public void testStabIncreasesDamage() {
+        Move charge = new Move("Charge", 10, 0, "", MoveType.BODY,
+                DinoType.CHARGER, List.of(), 1.0);
+        Move waitMove = new Move("Wait", 0, 0, List.of());
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50,
+                "assets/animals/allosaurus.png", 1, 1, List.of(charge), null,
+                List.of(DinoType.CHARGER));
+        Dinosaur defender = new Dinosaur("Defender", 100, 50,
+                "assets/animals/allosaurus.png", 1, 1, List.of(waitMove), null,
+                List.of(DinoType.BITER));
+        Player p1 = new Player(List.of(attacker));
+        Player p2 = new Player(List.of(defender));
+        Battle battle = new Battle(p1, p2);
+
+        battle.executeRound(charge, waitMove);
+        assertEquals(85, defender.getHealth());
+    }
+
+    @Test
+    public void testNoStabNormalDamage() {
+        Move charge = new Move("Charge", 10, 0, "", MoveType.BODY,
+                DinoType.CHARGER, List.of(), 1.0);
+        Move waitMove = new Move("Wait", 0, 0, List.of());
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50,
+                "assets/animals/allosaurus.png", 1, 1, List.of(charge), null,
+                List.of(DinoType.BITER));
+        Dinosaur defender = new Dinosaur("Defender", 100, 50,
+                "assets/animals/allosaurus.png", 1, 1, List.of(waitMove), null,
+                List.of(DinoType.BITER));
+        Player p1 = new Player(List.of(attacker));
+        Player p2 = new Player(List.of(defender));
+        Battle battle = new Battle(p1, p2);
+
+        battle.executeRound(charge, waitMove);
+        assertEquals(90, defender.getHealth());
+    }
+}


### PR DESCRIPTION
## Summary
- implement Same Type Attack Bonus (STAB) in damage calculations
- add helper `hasType` to `Dinosaur`
- update existing tests for STAB-adjusted damage
- add new test suite verifying STAB behavior

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687957c6c5e0832ebce00d9d6a3f30aa