### PR TITLE
Update move button damage logic

### DIFF
--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -11,6 +11,7 @@ import com.mesozoic.arena.model.Player;
 import com.mesozoic.arena.engine.MoveEffects;
 import com.mesozoic.arena.engine.AbilityEffects;
 import com.mesozoic.arena.engine.AilmentEffects;
+import com.mesozoic.arena.engine.DamageCalculator;
 import com.mesozoic.arena.model.Ailment;
 import java.util.ArrayList;
 import java.util.List;
@@ -211,12 +212,7 @@ public class Battle {
 
             applyMoveEffects(actingPlayer, opposingPlayer, move);
             if (!defenderBraced) {
-                double attackValue = move.getKind() == MoveType.HEAD
-                        ? attacker.getEffectiveHeadAttack()
-                        : attacker.getEffectiveBodyAttack();
-                double stab = attacker.hasType(move.getType()) ? 1.5 : 1.0;
-                double typeMultiplier = defender.getMultiplierFrom(move.getType());
-                int totalDamage = Math.toIntExact(Math.round(move.getDamage() * attackValue * stab * typeMultiplier));
+                int totalDamage = DamageCalculator.calculate(attacker, defender, move);
                 totalDamage = AbilityEffects.modifyIncomingDamage(defender, totalDamage);
                 int beforeHealth = defender.getHealth();
                 defender.adjustHealth(-totalDamage);

--- a/src/main/java/com/mesozoic/arena/engine/DamageCalculator.java
+++ b/src/main/java/com/mesozoic/arena/engine/DamageCalculator.java
@@ -1,0 +1,37 @@
+package com.mesozoic.arena.engine;
+
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.MoveType;
+
+/**
+ * Utility for calculating move damage before ability modifiers.
+ */
+public final class DamageCalculator {
+    private DamageCalculator() {
+    }
+
+    /**
+     * Computes the raw damage of a move after factoring in attack stats, STAB
+     * and type advantages.
+     *
+     * @param attacker the dinosaur using the move
+     * @param defender the opposing dinosaur
+     * @param move     the move being used
+     * @return the calculated damage value
+     */
+    public static int calculate(Dinosaur attacker, Dinosaur defender, Move move) {
+        if (attacker == null || move == null) {
+            return 0;
+        }
+        double attackStat = move.getKind() == MoveType.HEAD
+                ? attacker.getEffectiveHeadAttack()
+                : attacker.getEffectiveBodyAttack();
+        double stab = attacker.hasType(move.getType()) ? 1.5 : 1.0;
+        double typeMultiplier = defender == null ? 1.0
+                : defender.getMultiplierFrom(move.getType());
+        long baseDamage = Math.round(move.getDamage() * attackStat * stab
+                * typeMultiplier);
+        return Math.toIntExact(baseDamage);
+    }
+}

--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -6,6 +6,7 @@ import com.mesozoic.arena.model.DinoType;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.MoveType;
 import com.mesozoic.arena.model.Player;
+import com.mesozoic.arena.engine.DamageCalculator;
 
 import javax.swing.*;
 import java.awt.*;
@@ -334,10 +335,8 @@ public class MainWindow extends JFrame {
     }
 
     private JButton createMoveButton(Dinosaur dino, Move move, boolean playerSide) {
-        double attackValue = move.getKind() == MoveType.HEAD
-                ? dino.getEffectiveHeadAttack()
-                : dino.getEffectiveBodyAttack();
-        int damage = Math.toIntExact(Math.round(move.getDamage() * attackValue));
+        Dinosaur target = playerSide ? opponent.getActiveDinosaur() : player.getActiveDinosaur();
+        int damage = DamageCalculator.calculate(dino, target, move);
         String attackImg = iconHtml(ATTACK_ICON_PATH);
         String accuracyImg = iconHtml(ACCURACY_ICON_PATH);
         String label = String.format("<html>%s %s %d %s %.0f%s</html>",


### PR DESCRIPTION
## Summary
- centralize damage calculation in new `DamageCalculator`
- use `DamageCalculator` when dealing damage in `Battle`
- show accurate damage on move buttons by including STAB and type matchups

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6879666f6ab0832ea117aae059542073