### PR TITLE
Implement reusable copy methods

### DIFF
--- a/src/main/java/com/mesozoic/arena/data/DinosaurLoader.java
+++ b/src/main/java/com/mesozoic/arena/data/DinosaurLoader.java
@@ -60,7 +60,7 @@ public class DinosaurLoader {
         int limit = Math.min(count, shuffledDinosaurs.size());
         for (int index = 0; index < limit; index++) {
             Dinosaur template = shuffledDinosaurs.get(index);
-            selection.add(copyDinosaur(template));
+            selection.add(template.copy());
         }
         return selection;
     }
@@ -119,10 +119,7 @@ public class DinosaurLoader {
             for (String moveName : names) {
                 Move template = moveTemplates.get(moveName);
                 if (template != null) {
-                    moves.add(new Move(template.getName(), template.getDamage(),
-                            template.getPriority(), template.getDescription(),
-                            template.getKind(), template.getType(),
-                            template.getEffects(), template.getAccuracy()));
+                    moves.add(template.copy());
                 }
             }
         }
@@ -150,15 +147,7 @@ public class DinosaurLoader {
     }
 
     private Dinosaur copyDinosaur(Dinosaur source) {
-        List<Move> copiedMoves = new ArrayList<>();
-        for (Move move : source.getMoves()) {
-            copiedMoves.add(new Move(move.getName(), move.getDamage(),
-                    move.getPriority(),
-                    move.getDescription(), move.getKind(), move.getType(),
-                    move.getEffects(), move.getAccuracy()));
-        }
-        return new Dinosaur(source.getName(), source.getHealth(), source.getSpeed(), source.getImagePath(),
-                source.getHeadAttack(), source.getBodyAttack(), copiedMoves, source.getAbility(), source.getTypes());
+        return source.copy();
     }
 
     private Map<String, Move> loadMoves() throws IOException {

--- a/src/main/java/com/mesozoic/arena/model/Dinosaur.java
+++ b/src/main/java/com/mesozoic/arena/model/Dinosaur.java
@@ -204,6 +204,25 @@ public class Dinosaur {
         return Math.round((float) speed * stageMultiplier(speedStage));
     }
 
+    /**
+     * Creates a deep copy of this dinosaur instance.
+     */
+    public Dinosaur copy() {
+        List<Move> moveCopies = new ArrayList<>();
+        for (Move move : moves) {
+            moveCopies.add(move.copy());
+        }
+        List<DinoType> typeCopies = new ArrayList<>(types);
+
+        Dinosaur clone = new Dinosaur(name, maxHealth, speed, imagePath,
+                headAttack, bodyAttack, moveCopies, ability, typeCopies);
+        clone.health = health;
+        clone.attackStage = attackStage;
+        clone.speedStage = speedStage;
+        clone.ailments.addAll(ailments);
+        return clone;
+    }
+
     private int clampStage(int stage) {
         if (stage > 6) {
             return 6;

--- a/src/main/java/com/mesozoic/arena/model/Move.java
+++ b/src/main/java/com/mesozoic/arena/model/Move.java
@@ -84,4 +84,12 @@ public class Move {
         String withDamage = description.replace("XX", String.valueOf(realDamage));
         return withDamage.replace("YY", String.valueOf(accuracy));
     }
+
+    /**
+     * Returns a deep copy of this move.
+     */
+    public Move copy() {
+        return new Move(name, damage, priority, description, kind, type,
+                getEffects(), accuracy);
+    }
 }

--- a/src/main/java/com/mesozoic/arena/model/Player.java
+++ b/src/main/java/com/mesozoic/arena/model/Player.java
@@ -92,4 +92,23 @@ public class Player {
     public boolean hasRemainingDinosaurs() {
         return !dinosaurs.isEmpty();
     }
+
+    /**
+     * Creates a deep copy of this player including cloned dinosaurs.
+     */
+    public Player copy() {
+        List<Dinosaur> copies = new ArrayList<>();
+        for (Dinosaur d : dinosaurs) {
+            copies.add(d.copy());
+        }
+
+        Player clone = new Player(copies);
+        if (activeDinosaur != null) {
+            int index = dinosaurs.indexOf(activeDinosaur);
+            if (index >= 0 && index < copies.size()) {
+                clone.activeDinosaur = copies.get(index);
+            }
+        }
+        return clone;
+    }
 }

--- a/src/main/java/com/mesozoic/arena/util/DinosaurLoader.java
+++ b/src/main/java/com/mesozoic/arena/util/DinosaurLoader.java
@@ -74,9 +74,7 @@ public final class DinosaurLoader {
                     for (Object n : moveNames) {
                         Move m = moves.get(String.valueOf(n));
                         if (m != null) {
-                            dinoMoves.add(new Move(m.getName(), m.getDamage(),
-                                    m.getPriority(), m.getDescription(), m.getKind(), m.getType(),
-                                    m.getEffects(), m.getAccuracy()));
+                            dinoMoves.add(m.copy());
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- add `copy()` to `Move` for deep cloning
- implement deep copying in `Dinosaur.copy()` including health, stages, and ailments
- add `Player.copy()` that clones all dinosaurs and retains the active one
- refactor dinosaur loaders to use these new copy methods

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687b7276926c832e91988c2848b24ff2