### PR TITLE
Add MCTSAgent tests

### DIFF
--- a/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
@@ -1,0 +1,89 @@
+package com.mesozoic.arena;
+
+import com.mesozoic.arena.ai.mcts.MCTSAgent;
+import com.mesozoic.arena.engine.Battle;
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.Player;
+import com.mesozoic.arena.util.Config;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MCTSAgentTest {
+
+    private static Properties configProperties() throws Exception {
+        Field field = Config.class.getDeclaredField("properties");
+        field.setAccessible(true);
+        return (Properties) field.get(null);
+    }
+
+    private static String setUseLLMAgent(boolean value) throws Exception {
+        Properties props = configProperties();
+        String previous = props.getProperty("useLLMAgent");
+        props.setProperty("useLLMAgent", Boolean.toString(value));
+        return previous;
+    }
+
+    private static void restoreUseLLMAgent(String previous) throws Exception {
+        Properties props = configProperties();
+        if (previous == null) {
+            props.remove("useLLMAgent");
+        } else {
+            props.setProperty("useLLMAgent", previous);
+        }
+    }
+
+    @Test
+    public void testAgentChoosesWinningMove() throws Exception {
+        String original = setUseLLMAgent(false);
+        try {
+            Move win = new Move("Win", 10, 0, List.of());
+            Move wait = new Move("Wait", 0, 0, List.of());
+            Move foeAttack = new Move("Strike", 10, 0, List.of());
+            Dinosaur agentDino = new Dinosaur("Agent", 10, 10,
+                    "assets/animals/allosaurus.png", 1, 1,
+                    List.of(win, wait), null);
+            Dinosaur foeDino = new Dinosaur("Foe", 1, 5,
+                    "assets/animals/allosaurus.png", 1, 1,
+                    List.of(foeAttack), null);
+            Player self = new Player(List.of(agentDino));
+            Player enemy = new Player(List.of(foeDino));
+            MCTSAgent agent = new MCTSAgent(50, new Random(0));
+
+            for (int i = 0; i < 3; i++) {
+                Move chosen = agent.chooseMove(self, enemy, List.of());
+                assertEquals("Win", chosen.getName());
+            }
+        } finally {
+            restoreUseLLMAgent(original);
+        }
+    }
+
+    @Test
+    public void testBattleUsesMctsWhenLlmDisabled() throws Exception {
+        String original = setUseLLMAgent(false);
+        try {
+            Move wait = new Move("Wait", 0, 0, List.of());
+            Dinosaur playerDino = new Dinosaur("Player", 10, 5,
+                    "assets/animals/allosaurus.png", 1, 1,
+                    List.of(wait), null);
+            Dinosaur npcDino = new Dinosaur("NPC", 10, 5,
+                    "assets/animals/allosaurus.png", 1, 1,
+                    List.of(wait), null);
+            Player p1 = new Player(List.of(playerDino));
+            Player p2 = new Player(List.of(npcDino));
+            Battle battle = new Battle(p1, p2);
+
+            assertTrue(battle.getOpponentAI() instanceof MCTSAgent);
+        } finally {
+            restoreUseLLMAgent(original);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for MCTS agent behavior
- verify the AI chooses the winning move in a simple battle
- ensure Battle falls back to MCTS when the LLM is disabled

## Testing
- `mvn test -DtrimStackTrace=false -DfailIfNoTests=false`

------
https://chatgpt.com/codex/tasks/task_e_687b859d2c08832e8aca5e65cedfc6b0