### PR TITLE
Fix GameState constructor

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
@@ -19,11 +19,19 @@ public class GameState {
     /**
      * Creates a new simulation state from the given players.
      * Copies the players before constructing the internal battle.
+     * Entry abilities are not triggered again.
      */
     public GameState(Player playerOne, Player playerTwo) {
-        this(playerOne.copy(), playerTwo.copy(), true);
+        this(playerOne.copy(), playerTwo.copy(), false);
     }
 
+    /**
+     * Internal constructor controlling whether entry abilities are applied.
+     *
+     * @param playerOne   player representing the first side
+     * @param playerTwo   player representing the second side
+     * @param applyEntry  when true, active dinosaurs trigger entry abilities
+     */
     private GameState(Player playerOne, Player playerTwo, boolean applyEntry) {
         this.playerOne = playerOne;
         this.playerTwo = playerTwo;


### PR DESCRIPTION
## Summary
- avoid triggering entry abilities twice when creating a new `GameState`
- document the private constructor parameter

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687b97693f9c832e8a5a0bd8b191e579