### PR TITLE
Allow deterministic RNG for move hits

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
@@ -7,6 +7,7 @@ import com.mesozoic.arena.model.Player;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 /**
  * Lightweight representation of a battle state used for MCTS simulations.
@@ -58,11 +59,11 @@ public class GameState {
     /**
      * Produces the next game state after both players perform their moves.
      */
-    public GameState nextState(Move playerOneMove, Move playerTwoMove) {
+    public GameState nextState(Move playerOneMove, Move playerTwoMove, Random random) {
         Player nextPlayerOne = playerOne.copy();
         Player nextPlayerTwo = playerTwo.copy();
         GameState next = new GameState(nextPlayerOne, nextPlayerTwo, false);
-        next.battle.executeRound(playerOneMove, playerTwoMove);
+        next.battle.executeRound(playerOneMove, playerTwoMove, random);
         return next;
     }
 

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
@@ -64,7 +64,7 @@ public class MCTSNode {
         }
         Move chosenMove = untriedMoves.remove(random.nextInt(untriedMoves.size()));
         Move opponentMove = randomMove(state.getPlayerOne(), random);
-        GameState nextState = state.nextState(opponentMove, chosenMove);
+        GameState nextState = state.nextState(opponentMove, chosenMove, random);
         MCTSNode child = new MCTSNode(nextState, this, chosenMove);
         children.add(child);
         return child;
@@ -91,7 +91,7 @@ public class MCTSNode {
         while (!current.isTerminal()) {
             Move ourMove = randomMove(current.getPlayerTwo(), random);
             Move opponentMove = randomMove(current.getPlayerOne(), random);
-            current = current.nextState(opponentMove, ourMove);
+            current = current.nextState(opponentMove, ourMove, random);
         }
         int winner = current.winner();
         if (winner == -1) {

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -33,8 +33,8 @@ public class Battle {
     private int turn = 1;
     private Player winner;
 
-    private boolean moveHits(Move move) {
-        return move != null && Math.random() < move.getAccuracy();
+    private boolean moveHits(Move move, Random random) {
+        return move != null && random.nextDouble() < move.getAccuracy();
     }
 
     private void logMiss(Player actingPlayer, Dinosaur attacker, Move move) {
@@ -108,6 +108,10 @@ public class Battle {
      * The order of execution is determined by move priority and speed.
      */
     public void executeRound(Move playerOneMove, Move playerTwoMove) {
+        executeRound(playerOneMove, playerTwoMove, new Random());
+    }
+
+    public void executeRound(Move playerOneMove, Move playerTwoMove, Random random) {
         if (winner != null) {
             return;
         }
@@ -150,17 +154,17 @@ public class Battle {
 
         if (p1First) {
             p1Braced = MoveEffects.hasBraceEffect(playerOneMove, lastP1Action);
-            boolean fainted = performTurn(playerOne, playerTwo, playerOneMove, p2Braced);
+            boolean fainted = performTurn(playerOne, playerTwo, playerOneMove, p2Braced, random);
             if (winner == null && !fainted) {
                 p2Braced = MoveEffects.hasBraceEffect(playerTwoMove, lastP2Action);
-                performTurn(playerTwo, playerOne, playerTwoMove, p1Braced);
+                performTurn(playerTwo, playerOne, playerTwoMove, p1Braced, random);
             }
         } else {
             p2Braced = MoveEffects.hasBraceEffect(playerTwoMove, lastP2Action);
-            boolean fainted = performTurn(playerTwo, playerOne, playerTwoMove, p1Braced);
+            boolean fainted = performTurn(playerTwo, playerOne, playerTwoMove, p1Braced, random);
             if (winner == null && !fainted) {
                 p1Braced = MoveEffects.hasBraceEffect(playerOneMove, lastP1Action);
-                performTurn(playerOne, playerTwo, playerOneMove, p2Braced);
+                performTurn(playerOne, playerTwo, playerOneMove, p2Braced, random);
             }
         }
 
@@ -195,7 +199,7 @@ public class Battle {
     }
 
     private boolean performTurn(Player actingPlayer, Player opposingPlayer, Move move,
-            boolean defenderBraced) {
+            boolean defenderBraced, Random random) {
         int repeatCount = MoveEffects.getRepeatCount(move);
         boolean defenderFainted = false;
         for (int index = 0; index < repeatCount; index++) {
@@ -205,7 +209,7 @@ public class Battle {
                 return defenderFainted;
             }
 
-            if (!moveHits(move)) {
+            if (!moveHits(move, random)) {
                 logMiss(actingPlayer, attacker, move);
                 defenderBraced = false;
                 continue;


### PR DESCRIPTION
## Summary
- refactor `Battle.moveHits` to take a `Random`
- thread RNG through `executeRound`, `GameState.nextState` and MCTS search

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687b97990060832eaadeb024d3035615