### PR TITLE
Add GameState test for Intimidate

### DIFF
--- a/src/test/java/com/mesozoic/arena/GameStateTest.java
+++ b/src/test/java/com/mesozoic/arena/GameStateTest.java
@@ -1,0 +1,34 @@
+package com.mesozoic.arena;
+
+import com.mesozoic.arena.ai.mcts.GameState;
+import com.mesozoic.arena.engine.Battle;
+import com.mesozoic.arena.model.Ability;
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Player;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GameStateTest {
+
+    @Test
+    public void testIntimidateEffectNotStacked() {
+        Dinosaur intimidator = new Dinosaur(
+                "Intimidator", 100, 50, "assets/animals/allosaurus.png",
+                10, 10, List.of(), new Ability("Intimidate", ""));
+        Dinosaur target = new Dinosaur(
+                "Target", 100, 50, "assets/animals/allosaurus.png",
+                10, 10, List.of(), null);
+        Player playerOne = new Player(List.of(intimidator));
+        Player playerTwo = new Player(List.of(target));
+        new Battle(playerOne, playerTwo);
+        assertEquals(-1, target.getAttackStage());
+
+        GameState state = new GameState(playerOne, playerTwo);
+        int stage = state.getPlayerTwo().getActiveDinosaur().getAttackStage();
+        assertEquals(-1, stage);
+    }
+}


### PR DESCRIPTION
## Summary
- add GameStateTest to ensure entry abilities are not doubled

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687b9c2a9e3c832eb83c441ef2b7261a