### PR TITLE
Fix infinite rollouts

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
@@ -11,6 +11,7 @@ import java.util.Random;
  * Node used by the Monte Carlo Tree Search.
  */
 public class MCTSNode {
+    private static final int MAX_ROLLOUT_STEPS = 100;
     private final GameState state;
     private final MCTSNode parent;
     private final List<MCTSNode> children = new ArrayList<>();
@@ -88,10 +89,12 @@ public class MCTSNode {
 
     public int rollout(Random random) {
         GameState current = state;
-        while (!current.isTerminal()) {
+        int steps = 0;
+        while (!current.isTerminal() && steps < MAX_ROLLOUT_STEPS) {
             Move ourMove = randomMove(current.getPlayerTwo(), random);
             Move opponentMove = randomMove(current.getPlayerOne(), random);
             current = current.nextState(opponentMove, ourMove, random);
+            steps++;
         }
         int winner = current.winner();
         if (winner == -1) {

--- a/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
@@ -70,4 +70,24 @@ public class MCTSNodeTest {
         MCTSNode best = root.bestChild();
         assertEquals("Win", best.getMove().getName());
     }
+
+    @Test
+    public void testRolloutStopsWithoutWinner() {
+        Move waitOne = new Move("Wait", 0, 0, List.of());
+        Move waitTwo = new Move("Wait", 0, 0, List.of());
+        Dinosaur dinoOne = new Dinosaur("IdleOne", 10, 5,
+                "assets/animals/allosaurus.png", 1, 1,
+                List.of(waitOne), null);
+        Dinosaur dinoTwo = new Dinosaur("IdleTwo", 10, 5,
+                "assets/animals/allosaurus.png", 1, 1,
+                List.of(waitTwo), null);
+        Player p1 = new Player(List.of(dinoOne));
+        Player p2 = new Player(List.of(dinoTwo));
+        GameState state = new GameState(p1, p2);
+        MCTSNode root = new MCTSNode(state, null, null);
+        Random random = new Random(0);
+
+        int result = root.rollout(random);
+        assertEquals(0, result);
+    }
 }


### PR DESCRIPTION
## Summary
- limit MCTS rollout loops so simulations eventually end
- add test covering non-damaging move scenario

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_687ba60040f0832e90fe9c500fb03c4a