### PR TITLE
Log MCTS search stats

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
@@ -14,6 +14,7 @@ import java.util.Random;
 public class MCTSAgent implements OpponentAgent {
     private final int iterations;
     private final Random random;
+    private String lastStats = "";
 
     public MCTSAgent(int iterations, Random random) {
         this.iterations = iterations;
@@ -43,6 +44,23 @@ public class MCTSAgent implements OpponentAgent {
             node.backpropagate(result);
         }
 
+        StringBuilder summary = new StringBuilder();
+        for (MCTSNode child : root.getChildren()) {
+            if (child.getVisitCount() == 0) {
+                continue;
+            }
+            double average = child.getWinScore() / child.getVisitCount();
+            if (summary.length() > 0) {
+                summary.append("\n");
+            }
+            summary.append(child.getMove().getName())
+                    .append(": ")
+                    .append(child.getVisitCount())
+                    .append(" visits, avg score ")
+                    .append(String.format("%.2f", average));
+        }
+        lastStats = summary.toString();
+
         MCTSNode bestChild = null;
         int highestVisits = -1;
         for (MCTSNode child : root.getChildren()) {
@@ -61,5 +79,12 @@ public class MCTSAgent implements OpponentAgent {
         }
 
         return bestChild.getMove();
+    }
+
+    /**
+     * Returns a summary of statistics for the most recent search.
+     */
+    public String getLastStats() {
+        return lastStats;
     }
 }

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -184,7 +184,14 @@ public class Battle {
      * Executes a round using the AI to select the opponent's move.
      */
     public void executeRound(Move playerOneMove) {
-        Move playerTwoMove = opponentAI.chooseMove(playerTwo, playerOne, Collections.unmodifiableList(moveHistory));
+        Move playerTwoMove = opponentAI.chooseMove(playerTwo, playerOne,
+                Collections.unmodifiableList(moveHistory));
+        if (opponentAI instanceof MCTSAgent mcts) {
+            String stats = mcts.getLastStats();
+            if (stats != null && !stats.isBlank()) {
+                addAiLog(stats);
+            }
+        }
         logLLMResponse();
         executeRound(playerOneMove, playerTwoMove);
         turn++;

--- a/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
@@ -114,4 +114,29 @@ public class MCTSAgentTest {
             restoreUseLLMAgent(original);
         }
     }
+
+    @Test
+    public void testBattleLogsMctsStats() throws Exception {
+        String original = setUseLLMAgent(false);
+        try {
+            Move wait = new Move("Wait", 0, 0, List.of());
+            Dinosaur playerDino = new Dinosaur("Player", 10, 5,
+                    "assets/animals/allosaurus.png", 1, 1,
+                    List.of(wait), null);
+            Dinosaur npcDino = new Dinosaur("NPC", 10, 5,
+                    "assets/animals/allosaurus.png", 1, 1,
+                    List.of(wait), null);
+            Player p1 = new Player(List.of(playerDino));
+            Player p2 = new Player(List.of(npcDino));
+            Battle battle = new Battle(p1, p2, new MCTSAgent(5, new Random(0)));
+
+            battle.executeRound(wait);
+
+            List<String> log = battle.getAiLog();
+            assertFalse(log.isEmpty());
+            assertTrue(log.get(0).contains("visits"));
+        } finally {
+            restoreUseLLMAgent(original);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a `lastStats` field and `getLastStats` method to `MCTSAgent`
- summarize root child stats after search
- log MCTS stats in `Battle.executeRound`
- test that logs capture these stats

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687bac40de38832e8e5934ae21cfca59