### PR TITLE
Allow MCTS agent to switch dinosaurs

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
@@ -4,6 +4,7 @@ import com.mesozoic.arena.engine.Battle;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Player;
+import com.mesozoic.arena.model.SwitchMove;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +62,15 @@ public class GameState {
         if (active == null) {
             return List.of();
         }
-        return new ArrayList<>(active.getMoves());
+        List<Move> moves = new ArrayList<>(active.getMoves());
+        List<Dinosaur> roster = player.getDinosaurs();
+        for (int index = 0; index < roster.size(); index++) {
+            Dinosaur bench = roster.get(index);
+            if (!bench.equals(active)) {
+                moves.add(new SwitchMove(bench, index));
+            }
+        }
+        return moves;
     }
 
     /**
@@ -70,6 +79,18 @@ public class GameState {
     public GameState nextState(Move playerOneMove, Move playerTwoMove, Random random) {
         Player nextPlayerOne = playerOne.copy();
         Player nextPlayerTwo = playerTwo.copy();
+
+        if (playerOneMove instanceof SwitchMove switchOne) {
+            Dinosaur target = nextPlayerOne.getDinosaurs().get(switchOne.getTargetIndex());
+            nextPlayerOne.queueSwitch(target);
+            playerOneMove = null;
+        }
+        if (playerTwoMove instanceof SwitchMove switchTwo) {
+            Dinosaur target = nextPlayerTwo.getDinosaurs().get(switchTwo.getTargetIndex());
+            nextPlayerTwo.queueSwitch(target);
+            playerTwoMove = null;
+        }
+
         GameState next = new GameState(nextPlayerOne, nextPlayerTwo, false);
         next.battle.executeRound(playerOneMove, playerTwoMove, random);
         return next;

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
@@ -3,6 +3,8 @@ package com.mesozoic.arena.ai.mcts;
 import com.mesozoic.arena.ai.OpponentAgent;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Player;
+import com.mesozoic.arena.model.SwitchMove;
+import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.engine.TurnRecord;
 
 import java.util.List;
@@ -78,7 +80,17 @@ public class MCTSAgent implements OpponentAgent {
             return moves.get(random.nextInt(moves.size()));
         }
 
-        return bestChild.getMove();
+        Move chosen = bestChild.getMove();
+        if (chosen instanceof SwitchMove switchMove) {
+            List<Dinosaur> dinos = self.getDinosaurs();
+            if (switchMove.getTargetIndex() >= 0
+                    && switchMove.getTargetIndex() < dinos.size()) {
+                self.queueSwitch(dinos.get(switchMove.getTargetIndex()));
+            }
+            return null;
+        }
+
+        return chosen;
     }
 
     /**

--- a/src/main/java/com/mesozoic/arena/model/SwitchMove.java
+++ b/src/main/java/com/mesozoic/arena/model/SwitchMove.java
@@ -1,0 +1,22 @@
+package com.mesozoic.arena.model;
+
+import java.util.List;
+
+/**
+ * Represents the action of switching to another dinosaur.
+ */
+public class SwitchMove extends Move {
+    private final int targetIndex;
+
+    public SwitchMove(Dinosaur target, int index) {
+        super("Switch to " + target.getName(), 0, 0, List.of());
+        this.targetIndex = index;
+    }
+
+    /**
+     * Index of the dinosaur to switch to in the player's roster.
+     */
+    public int getTargetIndex() {
+        return targetIndex;
+    }
+}

--- a/src/test/java/com/mesozoic/arena/GameStateTest.java
+++ b/src/test/java/com/mesozoic/arena/GameStateTest.java
@@ -5,6 +5,8 @@ import com.mesozoic.arena.engine.Battle;
 import com.mesozoic.arena.model.Ability;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Player;
+import com.mesozoic.arena.model.Move;
+import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,5 +32,40 @@ public class GameStateTest {
         GameState state = new GameState(playerOne, playerTwo);
         int stage = state.getPlayerTwo().getActiveDinosaur().getAttackStage();
         assertEquals(-1, stage);
+    }
+
+    @Test
+    public void testAvailableMovesIncludeSwitch() {
+        Dinosaur first = new Dinosaur("First", 100, 50,
+                "assets/animals/allosaurus.png", 10, 10, List.of(), null);
+        Dinosaur second = new Dinosaur("Second", 100, 50,
+                "assets/animals/allosaurus.png", 10, 10, List.of(), null);
+        Player playerOne = new Player(List.of(first, second));
+        Player playerTwo = new Player(List.of(first.copy()));
+
+        GameState state = new GameState(playerOne, playerTwo);
+        boolean hasSwitch = state.availableMovesFor(state.getPlayerOne())
+                .stream()
+                .anyMatch(m -> m.getName().contains("Switch to Second"));
+        assertTrue(hasSwitch);
+    }
+
+    @Test
+    public void testNextStatePerformsSwitch() {
+        Dinosaur first = new Dinosaur("First", 100, 50,
+                "assets/animals/allosaurus.png", 10, 10, List.of(), null);
+        Dinosaur second = new Dinosaur("Second", 100, 50,
+                "assets/animals/allosaurus.png", 10, 10, List.of(), null);
+        Player playerOne = new Player(List.of(first, second));
+        Player playerTwo = new Player(List.of(first.copy()));
+
+        GameState state = new GameState(playerOne, playerTwo);
+        Move switchMove = state.availableMovesFor(state.getPlayerOne())
+                .stream()
+                .filter(m -> m.getName().contains("Switch to Second"))
+                .findFirst()
+                .orElseThrow();
+        GameState next = state.nextState(switchMove, null, new Random(0));
+        assertEquals("Second", next.getPlayerOne().getActiveDinosaur().getName());
     }
 }

--- a/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
@@ -143,4 +143,31 @@ public class MCTSAgentTest {
             restoreUseLLMAgent(original);
         }
     }
+
+    @Test
+    public void testAgentCanSwitch() throws Exception {
+        String original = setUseLLMAgent(false);
+        try {
+            Move wait = new Move("Wait", 0, 0, List.of());
+            Move strike = new Move("Strike", 10, 0, List.of());
+            Dinosaur active = new Dinosaur("Active", 10, 5,
+                    "assets/animals/allosaurus.png", 1, 1,
+                    List.of(), null);
+            Dinosaur bench = new Dinosaur("Bench", 10, 5,
+                    "assets/animals/allosaurus.png", 1, 1,
+                    List.of(strike), null);
+            Dinosaur foe = new Dinosaur("Foe", 10, 5,
+                    "assets/animals/allosaurus.png", 1, 1,
+                    List.of(wait), null);
+            Player self = new Player(List.of(active, bench));
+            Player enemy = new Player(List.of(foe));
+            MCTSAgent agent = new MCTSAgent(20, new Random(0));
+
+            Move chosen = agent.chooseMove(self, enemy, List.of());
+            assertNull(chosen);
+            assertEquals("Bench", self.getQueuedSwitch().getName());
+        } finally {
+            restoreUseLLMAgent(original);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- support switching via new `SwitchMove`
- add switch actions in GameState and handle them in MCTS agent
- test switching logic in GameState and MCTS agent

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_687bb277188c832eb414b08fe1f51f7b