### PR TITLE
Add move history tracking to simulations

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
@@ -5,6 +5,7 @@ import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Player;
 import com.mesozoic.arena.model.SwitchMove;
+import com.mesozoic.arena.engine.TurnRecord;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +18,7 @@ public class GameState {
     private final Player playerOne;
     private final Player playerTwo;
     private final Battle battle;
+    private final List<TurnRecord> history;
 
     /**
      * Creates a new simulation state from the given players.
@@ -24,7 +26,11 @@ public class GameState {
      * Entry abilities are not triggered again.
      */
     public GameState(Player playerOne, Player playerTwo) {
-        this(playerOne.copy(), playerTwo.copy(), false);
+        this(playerOne, playerTwo, List.of());
+    }
+
+    public GameState(Player playerOne, Player playerTwo, List<TurnRecord> history) {
+        this(playerOne.copy(), playerTwo.copy(), false, history);
     }
 
     /**
@@ -34,10 +40,11 @@ public class GameState {
      * @param playerTwo   player representing the second side
      * @param applyEntry  when true, active dinosaurs trigger entry abilities
      */
-    private GameState(Player playerOne, Player playerTwo, boolean applyEntry) {
+    private GameState(Player playerOne, Player playerTwo, boolean applyEntry, List<TurnRecord> history) {
         this.playerOne = playerOne;
         this.playerTwo = playerTwo;
-        this.battle = new Battle(this.playerOne, this.playerTwo);
+        this.history = history == null ? new ArrayList<>() : new ArrayList<>(history);
+        this.battle = new Battle(this.playerOne, this.playerTwo, this.history);
         if (!applyEntry) {
             revertEntryEffects();
         }
@@ -91,7 +98,8 @@ public class GameState {
             playerTwoMove = null;
         }
 
-        GameState next = new GameState(nextPlayerOne, nextPlayerTwo, false);
+        List<TurnRecord> nextHistory = new ArrayList<>(history);
+        GameState next = new GameState(nextPlayerOne, nextPlayerTwo, false, nextHistory);
         next.battle.executeRound(playerOneMove, playerTwoMove, random);
         return next;
     }

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -29,7 +29,7 @@ public class Battle {
     private final OpponentAgent opponentAI;
     private final List<String> eventLog = new ArrayList<>();
     private final List<String> aiLog = new ArrayList<>();
-    private final List<TurnRecord> moveHistory = new ArrayList<>();
+    private final List<TurnRecord> moveHistory;
     private int turn = 1;
     private Player winner;
 
@@ -43,13 +43,22 @@ public class Battle {
     }
 
     public Battle(Player playerOne, Player playerTwo) {
-        this(playerOne, playerTwo, createAgent());
+        this(playerOne, playerTwo, createAgent(), new ArrayList<>());
     }
 
     public Battle(Player playerOne, Player playerTwo, OpponentAgent opponentAI) {
+        this(playerOne, playerTwo, opponentAI, new ArrayList<>());
+    }
+
+    public Battle(Player playerOne, Player playerTwo, List<TurnRecord> history) {
+        this(playerOne, playerTwo, createAgent(), history);
+    }
+
+    public Battle(Player playerOne, Player playerTwo, OpponentAgent opponentAI, List<TurnRecord> history) {
         this.playerOne = playerOne;
         this.playerTwo = playerTwo;
         this.opponentAI = opponentAI;
+        this.moveHistory = history == null ? new ArrayList<>() : history;
         AbilityEffects.onEntry(playerOne.getActiveDinosaur(), playerTwo.getActiveDinosaur());
         AbilityEffects.onEntry(playerTwo.getActiveDinosaur(), playerOne.getActiveDinosaur());
     }

--- a/src/test/java/com/mesozoic/arena/GameStateTest.java
+++ b/src/test/java/com/mesozoic/arena/GameStateTest.java
@@ -6,6 +6,7 @@ import com.mesozoic.arena.model.Ability;
 import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Player;
 import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.Effect;
 import java.util.Random;
 
 import org.junit.jupiter.api.Test;
@@ -67,5 +68,24 @@ public class GameStateTest {
                 .orElseThrow();
         GameState next = state.nextState(switchMove, null, new Random(0));
         assertEquals("Second", next.getPlayerOne().getActiveDinosaur().getName());
+    }
+
+    @Test
+    public void testBraceFailsWhenRepeated() {
+        Move brace = new Move("Brace", 0, 0, List.of(new Effect("brace")));
+        Move strike = new Move("Strike", 10, 0, List.of());
+        Dinosaur defender = new Dinosaur("Defender", 100, 50,
+                "assets/animals/allosaurus.png", 1, 1, List.of(brace), null);
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50,
+                "assets/animals/allosaurus.png", 1, 1, List.of(strike), null);
+        Player p1 = new Player(List.of(defender));
+        Player p2 = new Player(List.of(attacker));
+
+        GameState state = new GameState(p1, p2);
+        state = state.nextState(brace, strike, new Random(0));
+        assertEquals(100, state.getPlayerOne().getActiveDinosaur().getHealth());
+
+        GameState next = state.nextState(brace, strike, new Random(0));
+        assertTrue(next.getPlayerOne().getActiveDinosaur().getHealth() < 100);
     }
 }


### PR DESCRIPTION
## Summary
- carry turn history in `GameState`
- allow `Battle` to start with an existing history list
- extend history in `GameState.nextState`
- test repeated Brace fails in simulations

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687bc6706054832e82f81c43987c6543