### PR TITLE
Improve MCTS logging

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
@@ -58,7 +58,11 @@ public class MCTSAgent implements OpponentAgent {
             summary.append(child.getMove().getName())
                     .append(": ")
                     .append(child.getVisitCount())
-                    .append(" visits, avg score ")
+                    .append(" visits, ")
+                    .append(child.getWinCount())
+                    .append(" wins, ")
+                    .append(child.getDrawCount())
+                    .append(" draws, avg score ")
                     .append(String.format("%.2f", average));
         }
         lastStats = summary.toString();

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
@@ -19,6 +19,8 @@ public class MCTSNode {
     private final Move move;
     private int visitCount;
     private double winScore;
+    private int winCount;
+    private int drawCount;
 
     public MCTSNode(GameState state, MCTSNode parent, Move move) {
         this.state = state;
@@ -45,6 +47,14 @@ public class MCTSNode {
 
     public double getWinScore() {
         return winScore;
+    }
+
+    public int getWinCount() {
+        return winCount;
+    }
+
+    public int getDrawCount() {
+        return drawCount;
     }
 
     public boolean isFullyExpanded() {
@@ -110,6 +120,11 @@ public class MCTSNode {
         while (node != null) {
             node.visitCount++;
             node.winScore += result;
+            if (result > 0) {
+                node.winCount++;
+            } else if (result == 0) {
+                node.drawCount++;
+            }
             node = node.parent;
         }
     }


### PR DESCRIPTION
## Summary
- track win and draw counts per node in MCTS
- surface win/draw stats in `MCTSAgent` logging

## Testing
- `mvn test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_687bc9ac6384832eb1604b7b89b6f74c