### PR TITLE
Fix RNG separation in MCTS

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
@@ -15,12 +15,22 @@ import java.util.Random;
  */
 public class MCTSAgent implements OpponentAgent {
     private final int iterations;
-    private final Random random;
+    private final Random selectionRandom;
+    private final Random simulationRandom;
     private String lastStats = "";
 
     public MCTSAgent(int iterations, Random random) {
+        long seed1 = random.nextLong();
+        long seed2 = random.nextLong();
         this.iterations = iterations;
-        this.random = random;
+        this.selectionRandom = new Random(seed1);
+        this.simulationRandom = new Random(seed2);
+    }
+
+    public MCTSAgent(int iterations, Random selectionRandom, Random simulationRandom) {
+        this.iterations = iterations;
+        this.selectionRandom = selectionRandom;
+        this.simulationRandom = simulationRandom;
     }
 
     @Override
@@ -39,10 +49,10 @@ public class MCTSAgent implements OpponentAgent {
             }
             if (!node.getState().isTerminal()) {
                 if (!node.isFullyExpanded()) {
-                    node = node.expand(random);
+                    node = node.expand(selectionRandom, simulationRandom);
                 }
             }
-            int result = node.rollout(random);
+            int result = node.rollout(simulationRandom);
             node.backpropagate(result);
         }
 
@@ -81,7 +91,7 @@ public class MCTSAgent implements OpponentAgent {
             if (moves.isEmpty()) {
                 return null;
             }
-            return moves.get(random.nextInt(moves.size()));
+            return moves.get(selectionRandom.nextInt(moves.size()));
         }
 
         Move chosen = bestChild.getMove();

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
@@ -69,13 +69,13 @@ public class MCTSNode {
         return moves.get(random.nextInt(moves.size()));
     }
 
-    public MCTSNode expand(Random random) {
+    public MCTSNode expand(Random selectionRandom, Random simulationRandom) {
         if (untriedMoves.isEmpty()) {
             return this;
         }
-        Move chosenMove = untriedMoves.remove(random.nextInt(untriedMoves.size()));
-        Move opponentMove = randomMove(state.getPlayerOne(), random);
-        GameState nextState = state.nextState(opponentMove, chosenMove, random);
+        Move chosenMove = untriedMoves.remove(selectionRandom.nextInt(untriedMoves.size()));
+        Move opponentMove = randomMove(state.getPlayerOne(), simulationRandom);
+        GameState nextState = state.nextState(opponentMove, chosenMove, simulationRandom);
         MCTSNode child = new MCTSNode(nextState, this, chosenMove);
         children.add(child);
         return child;
@@ -97,13 +97,13 @@ public class MCTSNode {
         return best;
     }
 
-    public int rollout(Random random) {
+    public int rollout(Random simulationRandom) {
         GameState current = state;
         int steps = 0;
         while (!current.isTerminal() && steps < MAX_ROLLOUT_STEPS) {
-            Move ourMove = randomMove(current.getPlayerTwo(), random);
-            Move opponentMove = randomMove(current.getPlayerOne(), random);
-            current = current.nextState(opponentMove, ourMove, random);
+            Move ourMove = randomMove(current.getPlayerTwo(), simulationRandom);
+            Move opponentMove = randomMove(current.getPlayerOne(), simulationRandom);
+            current = current.nextState(opponentMove, ourMove, simulationRandom);
             steps++;
         }
         int winner = current.winner();

--- a/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
@@ -58,7 +58,8 @@ public class MCTSAgentTest {
                     List.of(foeAttack), null);
             Player self = new Player(List.of(agentDino));
             Player enemy = new Player(List.of(foeDino));
-            MCTSAgent agent = new MCTSAgent(50, new Random(0));
+            Random rng = new Random(0);
+            MCTSAgent agent = new MCTSAgent(50, rng, rng);
 
             for (int i = 0; i < 3; i++) {
                 Move chosen = agent.chooseMove(self, enemy, List.of());
@@ -87,7 +88,8 @@ public class MCTSAgentTest {
                     List.of(wait), new Ability("Intimidate", ""));
             Player self = new Player(List.of(agentDino));
             Player enemy = new Player(List.of(intimidator));
-            MCTSAgent agent = new MCTSAgent(50, new Random(0));
+            Random rng = new Random(0);
+            MCTSAgent agent = new MCTSAgent(50, rng, rng);
 
             for (int i = 0; i < 3; i++) {
                 Move chosen = agent.chooseMove(self, enemy, List.of());
@@ -134,7 +136,8 @@ public class MCTSAgentTest {
                     List.of(wait), null);
             Player p1 = new Player(List.of(playerDino));
             Player p2 = new Player(List.of(npcDino));
-            Battle battle = new Battle(p1, p2, new MCTSAgent(5, new Random(0)));
+            Random rng = new Random(0);
+            Battle battle = new Battle(p1, p2, new MCTSAgent(5, rng, rng));
 
             battle.executeRound(wait);
 
@@ -163,7 +166,8 @@ public class MCTSAgentTest {
                     List.of(wait), null);
             Player self = new Player(List.of(active, bench));
             Player enemy = new Player(List.of(foe));
-            MCTSAgent agent = new MCTSAgent(20, new Random(0));
+            Random rng = new Random(0);
+            MCTSAgent agent = new MCTSAgent(20, rng, rng);
 
             Move chosen = agent.chooseMove(self, enemy, List.of());
             assertNull(chosen);
@@ -188,7 +192,8 @@ public class MCTSAgentTest {
                     List.of(strike), null);
             Player self = new Player(List.of(defender));
             Player enemy = new Player(List.of(attacker));
-            MCTSAgent agent = new MCTSAgent(30, new Random(0));
+            Random rng = new Random(0);
+            MCTSAgent agent = new MCTSAgent(30, rng, rng);
 
             TurnRecord last = new TurnRecord("Strike", "Brace");
             Move chosen = agent.chooseMove(self, enemy, List.of(last));

--- a/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
@@ -30,10 +30,11 @@ public class MCTSNodeTest {
         Player p2 = new Player(List.of(attacker));
         GameState state = new GameState(p1, p2);
         MCTSNode root = new MCTSNode(state, null, null);
-        Random random = new Random(0);
+        Random selectionRandom = new Random(0);
+        Random simulationRandom = new Random(1);
 
-        MCTSNode child = root.expand(random);
-        int result = child.rollout(random);
+        MCTSNode child = root.expand(selectionRandom, simulationRandom);
+        int result = child.rollout(simulationRandom);
         child.backpropagate(result);
 
         assertEquals(1, child.getVisitCount());
@@ -56,10 +57,11 @@ public class MCTSNodeTest {
         Player p2 = new Player(List.of(attacker));
         GameState state = new GameState(p1, p2);
         MCTSNode root = new MCTSNode(state, null, null);
-        Random random = new Random(0);
+        Random selectionRandom = new Random(0);
+        Random simulationRandom = new Random(1);
 
-        MCTSNode first = root.expand(random);
-        MCTSNode second = root.expand(random);
+        MCTSNode first = root.expand(selectionRandom, simulationRandom);
+        MCTSNode second = root.expand(selectionRandom, simulationRandom);
         if ("Win".equals(first.getMove().getName())) {
             first.backpropagate(1);
             second.backpropagate(-1);
@@ -86,9 +88,9 @@ public class MCTSNodeTest {
         Player p2 = new Player(List.of(dinoTwo));
         GameState state = new GameState(p1, p2);
         MCTSNode root = new MCTSNode(state, null, null);
-        Random random = new Random(0);
+        Random simulationRandom = new Random(0);
 
-        int result = root.rollout(random);
+        int result = root.rollout(simulationRandom);
         assertEquals(0, result);
     }
 
@@ -107,9 +109,9 @@ public class MCTSNodeTest {
         Player p2 = new Player(List.of(defender));
         GameState state = new GameState(p1, p2);
         MCTSNode root = new MCTSNode(state, null, null);
-        Random random = new Random(0);
+        Random simulationRandom = new Random(0);
 
-        int result = root.rollout(random);
+        int result = root.rollout(simulationRandom);
         assertEquals(-1, result);
     }
 }


### PR DESCRIPTION
## Summary
- add separate random generators for selection and simulation in the Monte Carlo agent
- update node expansion and rollout methods to accept two RNGs
- adjust tests to use identical RNGs for deterministic behaviour

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687bcfbdb51c832ea8b8c64428b6e2a0