### PR TITLE
Add MCTS expansion logging

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
@@ -17,6 +17,7 @@ public class MCTSAgent implements OpponentAgent {
     private final int iterations;
     private final Random random;
     private String lastStats = "";
+    private int expansionCounter = 0;
 
     public MCTSAgent(int iterations, Random random) {
         this.iterations = iterations;
@@ -31,6 +32,7 @@ public class MCTSAgent implements OpponentAgent {
 
         GameState rootState = new GameState(enemy, self, history);
         MCTSNode root = new MCTSNode(rootState, null, null);
+        expansionCounter = 0;
 
         for (int i = 0; i < iterations; i++) {
             MCTSNode node = root;
@@ -38,9 +40,23 @@ public class MCTSAgent implements OpponentAgent {
                 node = node.bestChild();
             }
             if (!node.getState().isTerminal()) {
+                boolean expanded = false;
+                Move expandedMove = null;
                 if (!node.isFullyExpanded()) {
                     node = node.expand(random);
+                    expanded = true;
+                    expandedMove = node.getMove();
+                    expansionCounter++;
+                    if (expandedMove != null) {
+                        System.out.println("Expansion " + expansionCounter + ": " + expandedMove.getName());
+                    }
                 }
+                int result = node.rollout(random);
+                if (expanded && expandedMove != null) {
+                    System.out.println("First rollout result for " + expandedMove.getName() + ": " + result);
+                }
+                node.backpropagate(result);
+                continue;
             }
             int result = node.rollout(random);
             node.backpropagate(result);


### PR DESCRIPTION
## Summary
- add expansionCounter in `MCTSAgent`
- log expansion order and first rollout results when expanding nodes

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_687bcf9dee98832e9bc90e71470bae01