### PR TITLE
Add epsilon-greedy exploration to MCTS agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ response. The final action should be provided on a line starting with
 When the LLM is disabled the game uses a Monte Carlo Tree Search agent. The
 search depth can be tuned through the `mctsIterations` option in
 `data/constants.ini`. Higher values yield stronger play at the cost of longer
-thinking time. The default is `1000` iterations.
+thinking time. The default is `1000` iterations. The `mctsEpsilon` option
+controls how often the agent explores random moves during search.

--- a/data/constants.ini
+++ b/data/constants.ini
@@ -1,3 +1,4 @@
 [DEFAULT]
 useLLMAgent=false
 mctsIterations=2000
+mctsEpsilon=0.1

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
@@ -17,21 +17,30 @@ public class MCTSAgent implements OpponentAgent {
     private final int iterations;
     private final Random selectionRandom;
     private final Random simulationRandom;
+    private final double epsilon;
     private String lastStats = "";
     private int expansionCounter = 0;
 
     public MCTSAgent(int iterations, Random random) {
-        long seed1 = random.nextLong();
-        long seed2 = random.nextLong();
-        this.iterations = iterations;
-        this.selectionRandom = new Random(seed1);
-        this.simulationRandom = new Random(seed2);
+        this(iterations, new Random(random.nextLong()),
+                new Random(random.nextLong()), 0.1);
+    }
+
+    public MCTSAgent(int iterations, Random random, double epsilon) {
+        this(iterations, new Random(random.nextLong()),
+                new Random(random.nextLong()), epsilon);
     }
 
     public MCTSAgent(int iterations, Random selectionRandom, Random simulationRandom) {
+        this(iterations, selectionRandom, simulationRandom, 0.1);
+    }
+
+    public MCTSAgent(int iterations, Random selectionRandom, Random simulationRandom,
+            double epsilon) {
         this.iterations = iterations;
         this.selectionRandom = selectionRandom;
         this.simulationRandom = simulationRandom;
+        this.epsilon = epsilon;
     }
 
     @Override
@@ -47,7 +56,7 @@ public class MCTSAgent implements OpponentAgent {
         for (int i = 0; i < iterations; i++) {
             MCTSNode node = root;
             while (node.isFullyExpanded() && !node.getChildren().isEmpty()) {
-                node = node.bestChild();
+                node = node.bestChild(selectionRandom, epsilon);
             }
             if (!node.getState().isTerminal()) {
                 boolean expanded = false;
@@ -61,7 +70,7 @@ public class MCTSAgent implements OpponentAgent {
                         System.out.println("Expansion " + expansionCounter + ": " + expandedMove.getName());
                     }
                 }
-                int result = node.rollout(random);
+                int result = node.rollout(simulationRandom);
                 if (expanded && expandedMove != null) {
                     System.out.println("First rollout result for " + expandedMove.getName() + ": " + result);
                 }
@@ -100,6 +109,11 @@ public class MCTSAgent implements OpponentAgent {
                 highestVisits = child.getVisitCount();
                 bestChild = child;
             }
+        }
+        if (!root.getChildren().isEmpty()
+                && selectionRandom.nextDouble() < epsilon) {
+            bestChild = root.getChildren()
+                    .get(selectionRandom.nextInt(root.getChildren().size()));
         }
 
         if (bestChild == null) {

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
@@ -81,13 +81,18 @@ public class MCTSNode {
         return child;
     }
 
-    public MCTSNode bestChild() {
+    public MCTSNode bestChild(Random random, double epsilon) {
+        if (random != null && epsilon > 0 && !children.isEmpty()
+                && random.nextDouble() < epsilon) {
+            return children.get(random.nextInt(children.size()));
+        }
         double exploration = 5.0;
         MCTSNode best = null;
         double bestValue = Double.NEGATIVE_INFINITY;
         for (MCTSNode child : children) {
             double exploitation = child.winScore / (child.visitCount + 1e-6);
-            double exploreTerm = Math.sqrt(Math.log(visitCount + 1) / (child.visitCount + 1e-6));
+            double exploreTerm = Math.sqrt(Math.log(visitCount + 1)
+                    / (child.visitCount + 1e-6));
             double uctValue = exploitation + exploration * exploreTerm;
             if (uctValue > bestValue) {
                 bestValue = uctValue;
@@ -95,6 +100,10 @@ public class MCTSNode {
             }
         }
         return best;
+    }
+
+    public MCTSNode bestChild() {
+        return bestChild(null, 0.0);
     }
 
     public int rollout(Random simulationRandom) {

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -101,7 +101,8 @@ public class Battle {
                 System.err.println("Falling back to MCTS opponent");
             }
         }
-        return new MCTSAgent(Config.mctsIterations(), new Random());
+        return new MCTSAgent(Config.mctsIterations(), new Random(),
+                Config.mctsEpsilon());
     }
 
     private void addEvent(String message) {

--- a/src/main/java/com/mesozoic/arena/util/Config.java
+++ b/src/main/java/com/mesozoic/arena/util/Config.java
@@ -58,6 +58,18 @@ public final class Config {
         }
     }
 
+    /**
+     * Returns the epsilon value used by the MCTS agent.
+     */
+    public static double mctsEpsilon() {
+        String value = properties.getProperty("mctsEpsilon", "0.1");
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException ignored) {
+            return 0.1;
+        }
+    }
+
 
     /**
      * Returns the Gemini API key from {@code gemini.env} or an empty string if

--- a/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
@@ -59,7 +59,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(agentDino));
             Player enemy = new Player(List.of(foeDino));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(50, rng, rng);
+            MCTSAgent agent = new MCTSAgent(50, rng, rng, 0.0);
 
             for (int i = 0; i < 3; i++) {
                 Move chosen = agent.chooseMove(self, enemy, List.of());
@@ -89,7 +89,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(agentDino));
             Player enemy = new Player(List.of(intimidator));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(50, rng, rng);
+            MCTSAgent agent = new MCTSAgent(50, rng, rng, 0.0);
 
             for (int i = 0; i < 3; i++) {
                 Move chosen = agent.chooseMove(self, enemy, List.of());
@@ -137,7 +137,7 @@ public class MCTSAgentTest {
             Player p1 = new Player(List.of(playerDino));
             Player p2 = new Player(List.of(npcDino));
             Random rng = new Random(0);
-            Battle battle = new Battle(p1, p2, new MCTSAgent(5, rng, rng));
+            Battle battle = new Battle(p1, p2, new MCTSAgent(5, rng, rng, 0.0));
 
             battle.executeRound(wait);
 
@@ -167,7 +167,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(active, bench));
             Player enemy = new Player(List.of(foe));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(20, rng, rng);
+            MCTSAgent agent = new MCTSAgent(20, rng, rng, 0.0);
 
             Move chosen = agent.chooseMove(self, enemy, List.of());
             assertNull(chosen);
@@ -193,7 +193,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(defender));
             Player enemy = new Player(List.of(attacker));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(30, rng, rng);
+            MCTSAgent agent = new MCTSAgent(30, rng, rng, 0.0);
 
             TurnRecord last = new TurnRecord("Strike", "Brace");
             Move chosen = agent.chooseMove(self, enemy, List.of(last));

--- a/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
@@ -75,6 +75,35 @@ public class MCTSNodeTest {
     }
 
     @Test
+    public void testBestChildEpsilonGreedy() {
+        Move first = new Move("First", 0, 0, List.of());
+        Move second = new Move("Second", 0, 0, List.of());
+        Dinosaur attacker = new Dinosaur("Attacker", 10, 5,
+                "assets/animals/allosaurus.png", 1, 1,
+                List.of(first, second), null);
+        Dinosaur defender = new Dinosaur("Defender", 10, 5,
+                "assets/animals/allosaurus.png", 1, 1,
+                List.of(first), null);
+        Player p1 = new Player(List.of(defender));
+        Player p2 = new Player(List.of(attacker));
+        GameState state = new GameState(p1, p2);
+        MCTSNode root = new MCTSNode(state, null, null);
+        Random selectionRandom = new Random(0);
+        Random simulationRandom = new Random(1);
+
+        root.expand(selectionRandom, simulationRandom);
+        root.expand(selectionRandom, simulationRandom);
+
+        Random epsilonRandom = new Random(0);
+        MCTSNode chosen = root.bestChild(epsilonRandom, 1.0);
+
+        Random expectedRandom = new Random(0);
+        expectedRandom.nextDouble();
+        int expectedIndex = expectedRandom.nextInt(root.getChildren().size());
+        assertEquals(root.getChildren().get(expectedIndex), chosen);
+    }
+
+    @Test
     public void testRolloutStopsWithoutWinner() {
         Move waitOne = new Move("Wait", 0, 0, List.of());
         Move waitTwo = new Move("Wait", 0, 0, List.of());


### PR DESCRIPTION
## Summary
- introduce `mctsEpsilon` config for Monte Carlo agent
- implement epsilon-greedy selection in `MCTSAgent` and `MCTSNode`
- update battle to pass epsilon from config
- document exploration setting in README
- ensure tests create agents with deterministic epsilon and add new epsilon test

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_687c10d8cb1c832eb1b9837e53d5fc2e