### PR TITLE
Add self-minimax probability to MCTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,6 @@ search depth can be tuned through the `mctsIterations` option in
 `data/constants.ini`. Higher values yield stronger play at the cost of longer
 thinking time. The default is `1000` iterations. The `mctsEpsilon` option
 controls how often the agent explores random moves during search.
+The `mctsSelfMinimaxProbability` option determines how often the agent
+selects a minimax move during rollouts. Set to `1.0` for purely minimax
+rollouts or `0.0` for random self play. The default is `0.5`.

--- a/data/constants.ini
+++ b/data/constants.ini
@@ -2,3 +2,4 @@
 useLLMAgent=false
 mctsIterations=5000
 mctsEpsilon=0.1
+mctsSelfMinimaxProbability=0.5

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
@@ -18,29 +18,36 @@ public class MCTSAgent implements OpponentAgent {
     private final Random selectionRandom;
     private final Random simulationRandom;
     private final double epsilon;
+    private final double selfProbability;
     private String lastStats = "";
     private int expansionCounter = 0;
 
     public MCTSAgent(int iterations, Random random) {
         this(iterations, new Random(random.nextLong()),
-                new Random(random.nextLong()), 0.1);
+                new Random(random.nextLong()), 0.1, 0.5);
     }
 
     public MCTSAgent(int iterations, Random random, double epsilon) {
         this(iterations, new Random(random.nextLong()),
-                new Random(random.nextLong()), epsilon);
+                new Random(random.nextLong()), epsilon, 0.5);
     }
 
     public MCTSAgent(int iterations, Random selectionRandom, Random simulationRandom) {
-        this(iterations, selectionRandom, simulationRandom, 0.1);
+        this(iterations, selectionRandom, simulationRandom, 0.1, 0.5);
     }
 
     public MCTSAgent(int iterations, Random selectionRandom, Random simulationRandom,
             double epsilon) {
+        this(iterations, selectionRandom, simulationRandom, epsilon, 0.5);
+    }
+
+    public MCTSAgent(int iterations, Random selectionRandom, Random simulationRandom,
+            double epsilon, double selfMinimaxProbability) {
         this.iterations = iterations;
         this.selectionRandom = selectionRandom;
         this.simulationRandom = simulationRandom;
         this.epsilon = epsilon;
+        this.selfProbability = selfMinimaxProbability;
     }
 
     @Override
@@ -50,7 +57,7 @@ public class MCTSAgent implements OpponentAgent {
         }
 
         GameState rootState = new GameState(enemy, self, history);
-        MCTSNode root = new MCTSNode(rootState, null, null);
+        MCTSNode root = new MCTSNode(rootState, null, null, selfProbability);
         expansionCounter = 0;
 
         for (int i = 0; i < iterations; i++) {

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -101,8 +101,10 @@ public class Battle {
                 System.err.println("Falling back to MCTS opponent");
             }
         }
-        return new MCTSAgent(Config.mctsIterations(), new Random(),
-                Config.mctsEpsilon());
+        Random rng = new Random();
+        return new MCTSAgent(Config.mctsIterations(), new Random(rng.nextLong()),
+                new Random(rng.nextLong()), Config.mctsEpsilon(),
+                Config.mctsSelfMinimaxProbability());
     }
 
     private void addEvent(String message) {

--- a/src/main/java/com/mesozoic/arena/util/Config.java
+++ b/src/main/java/com/mesozoic/arena/util/Config.java
@@ -70,6 +70,18 @@ public final class Config {
         }
     }
 
+    /**
+     * Returns the probability of using a minimax move during rollouts.
+     */
+    public static double mctsSelfMinimaxProbability() {
+        String value = properties.getProperty("mctsSelfMinimaxProbability", "0.5");
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException ignored) {
+            return 0.5;
+        }
+    }
+
 
     /**
      * Returns the Gemini API key from {@code gemini.env} or an empty string if

--- a/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
@@ -59,7 +59,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(agentDino));
             Player enemy = new Player(List.of(foeDino));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(50, rng, rng, 0.0);
+            MCTSAgent agent = new MCTSAgent(50, rng, rng, 0.0, 0.0);
 
             for (int i = 0; i < 3; i++) {
                 Move chosen = agent.chooseMove(self, enemy, List.of());
@@ -89,7 +89,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(agentDino));
             Player enemy = new Player(List.of(intimidator));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(50, rng, rng, 0.0);
+            MCTSAgent agent = new MCTSAgent(50, rng, rng, 0.0, 0.0);
 
             for (int i = 0; i < 3; i++) {
                 Move chosen = agent.chooseMove(self, enemy, List.of());
@@ -137,7 +137,7 @@ public class MCTSAgentTest {
             Player p1 = new Player(List.of(playerDino));
             Player p2 = new Player(List.of(npcDino));
             Random rng = new Random(0);
-            Battle battle = new Battle(p1, p2, new MCTSAgent(5, rng, rng, 0.0));
+            Battle battle = new Battle(p1, p2, new MCTSAgent(5, rng, rng, 0.0, 0.0));
 
             battle.executeRound(wait);
 
@@ -167,7 +167,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(active, bench));
             Player enemy = new Player(List.of(foe));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(20, rng, rng, 0.0);
+            MCTSAgent agent = new MCTSAgent(20, rng, rng, 0.0, 0.0);
 
             Move chosen = agent.chooseMove(self, enemy, List.of());
             assertNull(chosen);
@@ -193,7 +193,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(defender));
             Player enemy = new Player(List.of(attacker));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(30, rng, rng, 0.0);
+            MCTSAgent agent = new MCTSAgent(30, rng, rng, 0.0, 0.0);
 
             TurnRecord last = new TurnRecord("Strike", "Brace");
             Move chosen = agent.chooseMove(self, enemy, List.of(last));

--- a/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
@@ -29,7 +29,7 @@ public class MCTSNodeTest {
         Player p1 = new Player(List.of(defender));
         Player p2 = new Player(List.of(attacker));
         GameState state = new GameState(p1, p2);
-        MCTSNode root = new MCTSNode(state, null, null);
+        MCTSNode root = new MCTSNode(state, null, null, 0.0);
         Random selectionRandom = new Random(0);
         Random simulationRandom = new Random(1);
 
@@ -56,7 +56,7 @@ public class MCTSNodeTest {
         Player p1 = new Player(List.of(defender));
         Player p2 = new Player(List.of(attacker));
         GameState state = new GameState(p1, p2);
-        MCTSNode root = new MCTSNode(state, null, null);
+        MCTSNode root = new MCTSNode(state, null, null, 0.0);
         Random selectionRandom = new Random(0);
         Random simulationRandom = new Random(1);
 
@@ -87,7 +87,7 @@ public class MCTSNodeTest {
         Player p1 = new Player(List.of(defender));
         Player p2 = new Player(List.of(attacker));
         GameState state = new GameState(p1, p2);
-        MCTSNode root = new MCTSNode(state, null, null);
+        MCTSNode root = new MCTSNode(state, null, null, 0.0);
         Random selectionRandom = new Random(0);
         Random simulationRandom = new Random(1);
 
@@ -116,7 +116,7 @@ public class MCTSNodeTest {
         Player p1 = new Player(List.of(dinoOne));
         Player p2 = new Player(List.of(dinoTwo));
         GameState state = new GameState(p1, p2);
-        MCTSNode root = new MCTSNode(state, null, null);
+        MCTSNode root = new MCTSNode(state, null, null, 0.0);
         Random simulationRandom = new Random(0);
 
         int result = root.rollout(simulationRandom);
@@ -137,7 +137,7 @@ public class MCTSNodeTest {
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(defender));
         GameState state = new GameState(p1, p2);
-        MCTSNode root = new MCTSNode(state, null, null);
+        MCTSNode root = new MCTSNode(state, null, null, 0.0);
         Random simulationRandom = new Random(0);
 
         int result = root.rollout(simulationRandom);


### PR DESCRIPTION
## Summary
- add `mctsSelfMinimaxProbability` to constants.ini
- expose the new setting through `Config`
- pass the value when Battle creates `MCTSAgent`
- update `MCTSAgent` and `MCTSNode` to use the probability
- implement smarter rollout move selection
- adjust unit tests
- document new property in README

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687ca1220688832e90f84a9e39802535