### PR TITLE
Add opponent minimax probability

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ controls how often the agent explores random moves during search.
 The `mctsSelfMinimaxProbability` option determines how often the agent
 selects a minimax move during rollouts. Set to `1.0` for purely minimax
 rollouts or `0.0` for random self play. The default is `0.5`.
+The `mctsOpponentMinimaxProbability` option controls how often the
+simulations assume the human will choose a minimax move. The default is
+`0.75`.

--- a/data/constants.ini
+++ b/data/constants.ini
@@ -3,3 +3,4 @@ useLLMAgent=false
 mctsIterations=5000
 mctsEpsilon=0.1
 mctsSelfMinimaxProbability=0.5
+mctsOpponentMinimaxProbability=0.75

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
@@ -19,35 +19,37 @@ public class MCTSAgent implements OpponentAgent {
     private final Random simulationRandom;
     private final double epsilon;
     private final double selfProbability;
+    private final double opponentProbability;
     private String lastStats = "";
     private int expansionCounter = 0;
 
     public MCTSAgent(int iterations, Random random) {
         this(iterations, new Random(random.nextLong()),
-                new Random(random.nextLong()), 0.1, 0.5);
+                new Random(random.nextLong()), 0.1, 0.5, 0.75);
     }
 
     public MCTSAgent(int iterations, Random random, double epsilon) {
         this(iterations, new Random(random.nextLong()),
-                new Random(random.nextLong()), epsilon, 0.5);
+                new Random(random.nextLong()), epsilon, 0.5, 0.75);
     }
 
     public MCTSAgent(int iterations, Random selectionRandom, Random simulationRandom) {
-        this(iterations, selectionRandom, simulationRandom, 0.1, 0.5);
+        this(iterations, selectionRandom, simulationRandom, 0.1, 0.5, 0.75);
     }
 
     public MCTSAgent(int iterations, Random selectionRandom, Random simulationRandom,
             double epsilon) {
-        this(iterations, selectionRandom, simulationRandom, epsilon, 0.5);
+        this(iterations, selectionRandom, simulationRandom, epsilon, 0.5, 0.75);
     }
 
     public MCTSAgent(int iterations, Random selectionRandom, Random simulationRandom,
-            double epsilon, double selfMinimaxProbability) {
+            double epsilon, double selfMinimaxProbability, double opponentMinimaxProbability) {
         this.iterations = iterations;
         this.selectionRandom = selectionRandom;
         this.simulationRandom = simulationRandom;
         this.epsilon = epsilon;
         this.selfProbability = selfMinimaxProbability;
+        this.opponentProbability = opponentMinimaxProbability;
     }
 
     @Override
@@ -57,7 +59,8 @@ public class MCTSAgent implements OpponentAgent {
         }
 
         GameState rootState = new GameState(enemy, self, history);
-        MCTSNode root = new MCTSNode(rootState, null, null, selfProbability);
+        MCTSNode root = new MCTSNode(rootState, null, null,
+                selfProbability, opponentProbability);
         expansionCounter = 0;
 
         for (int i = 0; i < iterations; i++) {

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -104,7 +104,8 @@ public class Battle {
         Random rng = new Random();
         return new MCTSAgent(Config.mctsIterations(), new Random(rng.nextLong()),
                 new Random(rng.nextLong()), Config.mctsEpsilon(),
-                Config.mctsSelfMinimaxProbability());
+                Config.mctsSelfMinimaxProbability(),
+                Config.mctsOpponentMinimaxProbability());
     }
 
     private void addEvent(String message) {

--- a/src/main/java/com/mesozoic/arena/util/Config.java
+++ b/src/main/java/com/mesozoic/arena/util/Config.java
@@ -82,6 +82,18 @@ public final class Config {
         }
     }
 
+    /**
+     * Returns the probability of the opponent using a minimax move.
+     */
+    public static double mctsOpponentMinimaxProbability() {
+        String value = properties.getProperty("mctsOpponentMinimaxProbability", "0.75");
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException ignored) {
+            return 0.75;
+        }
+    }
+
 
     /**
      * Returns the Gemini API key from {@code gemini.env} or an empty string if

--- a/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSAgentTest.java
@@ -59,7 +59,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(agentDino));
             Player enemy = new Player(List.of(foeDino));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(50, rng, rng, 0.0, 0.0);
+            MCTSAgent agent = new MCTSAgent(50, rng, rng, 0.0, 0.0, 0.0);
 
             for (int i = 0; i < 3; i++) {
                 Move chosen = agent.chooseMove(self, enemy, List.of());
@@ -89,7 +89,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(agentDino));
             Player enemy = new Player(List.of(intimidator));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(50, rng, rng, 0.0, 0.0);
+            MCTSAgent agent = new MCTSAgent(50, rng, rng, 0.0, 0.0, 0.0);
 
             for (int i = 0; i < 3; i++) {
                 Move chosen = agent.chooseMove(self, enemy, List.of());
@@ -137,7 +137,7 @@ public class MCTSAgentTest {
             Player p1 = new Player(List.of(playerDino));
             Player p2 = new Player(List.of(npcDino));
             Random rng = new Random(0);
-            Battle battle = new Battle(p1, p2, new MCTSAgent(5, rng, rng, 0.0, 0.0));
+            Battle battle = new Battle(p1, p2, new MCTSAgent(5, rng, rng, 0.0, 0.0, 0.0));
 
             battle.executeRound(wait);
 
@@ -167,7 +167,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(active, bench));
             Player enemy = new Player(List.of(foe));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(20, rng, rng, 0.0, 0.0);
+            MCTSAgent agent = new MCTSAgent(20, rng, rng, 0.0, 0.0, 0.0);
 
             Move chosen = agent.chooseMove(self, enemy, List.of());
             assertNull(chosen);
@@ -193,7 +193,7 @@ public class MCTSAgentTest {
             Player self = new Player(List.of(defender));
             Player enemy = new Player(List.of(attacker));
             Random rng = new Random(0);
-            MCTSAgent agent = new MCTSAgent(30, rng, rng, 0.0, 0.0);
+            MCTSAgent agent = new MCTSAgent(30, rng, rng, 0.0, 0.0, 0.0);
 
             TurnRecord last = new TurnRecord("Strike", "Brace");
             Move chosen = agent.chooseMove(self, enemy, List.of(last));

--- a/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
@@ -29,7 +29,7 @@ public class MCTSNodeTest {
         Player p1 = new Player(List.of(defender));
         Player p2 = new Player(List.of(attacker));
         GameState state = new GameState(p1, p2);
-        MCTSNode root = new MCTSNode(state, null, null, 0.0);
+        MCTSNode root = new MCTSNode(state, null, null, 0.0, 0.0);
         Random selectionRandom = new Random(0);
         Random simulationRandom = new Random(1);
 
@@ -56,7 +56,7 @@ public class MCTSNodeTest {
         Player p1 = new Player(List.of(defender));
         Player p2 = new Player(List.of(attacker));
         GameState state = new GameState(p1, p2);
-        MCTSNode root = new MCTSNode(state, null, null, 0.0);
+        MCTSNode root = new MCTSNode(state, null, null, 0.0, 0.0);
         Random selectionRandom = new Random(0);
         Random simulationRandom = new Random(1);
 
@@ -87,7 +87,7 @@ public class MCTSNodeTest {
         Player p1 = new Player(List.of(defender));
         Player p2 = new Player(List.of(attacker));
         GameState state = new GameState(p1, p2);
-        MCTSNode root = new MCTSNode(state, null, null, 0.0);
+        MCTSNode root = new MCTSNode(state, null, null, 0.0, 0.0);
         Random selectionRandom = new Random(0);
         Random simulationRandom = new Random(1);
 
@@ -116,7 +116,7 @@ public class MCTSNodeTest {
         Player p1 = new Player(List.of(dinoOne));
         Player p2 = new Player(List.of(dinoTwo));
         GameState state = new GameState(p1, p2);
-        MCTSNode root = new MCTSNode(state, null, null, 0.0);
+        MCTSNode root = new MCTSNode(state, null, null, 0.0, 0.0);
         Random simulationRandom = new Random(0);
 
         int result = root.rollout(simulationRandom);
@@ -137,7 +137,7 @@ public class MCTSNodeTest {
         Player p1 = new Player(List.of(attacker));
         Player p2 = new Player(List.of(defender));
         GameState state = new GameState(p1, p2);
-        MCTSNode root = new MCTSNode(state, null, null, 0.0);
+        MCTSNode root = new MCTSNode(state, null, null, 0.0, 0.0);
         Random simulationRandom = new Random(0);
 
         int result = root.rollout(simulationRandom);


### PR DESCRIPTION
## Summary
- allow MCTS to use minimax for modeling the player with new `mctsOpponentMinimaxProbability` config
- default to 0.75 in `constants.ini`
- update configuration loader
- add support for new value in `Battle` and `MCTSAgent`
- update MCTS logic and tests

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_687ca6024904832e975b70443075c922