### PR TITLE
Fix switch index in MCTS simulations

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
@@ -87,21 +87,25 @@ public class GameState {
         Player nextPlayerOne = playerOne.copy();
         Player nextPlayerTwo = playerTwo.copy();
 
-        if (playerOneMove instanceof SwitchMove switchOne) {
-            Dinosaur target = nextPlayerOne.getDinosaurs().get(switchOne.getTargetIndex());
-            nextPlayerOne.queueSwitch(target);
-            playerOneMove = null;
-        }
-        if (playerTwoMove instanceof SwitchMove switchTwo) {
-            Dinosaur target = nextPlayerTwo.getDinosaurs().get(switchTwo.getTargetIndex());
-            nextPlayerTwo.queueSwitch(target);
-            playerTwoMove = null;
-        }
+        playerOneMove = applySwitchMove(nextPlayerOne, playerOneMove);
+        playerTwoMove = applySwitchMove(nextPlayerTwo, playerTwoMove);
 
         List<TurnRecord> nextHistory = new ArrayList<>(history);
         GameState next = new GameState(nextPlayerOne, nextPlayerTwo, false, nextHistory);
         next.battle.executeRound(playerOneMove, playerTwoMove, random);
         return next;
+    }
+
+    private static Move applySwitchMove(Player player, Move move) {
+        if (move instanceof SwitchMove switchMove) {
+            List<Dinosaur> dinos = player.getDinosaurs();
+            int index = switchMove.getTargetIndex();
+            if (index >= 0 && index < dinos.size()) {
+                player.queueSwitch(dinos.get(index));
+            }
+            return null;
+        }
+        return move;
     }
 
     /**

--- a/src/test/java/com/mesozoic/arena/GameStateTest.java
+++ b/src/test/java/com/mesozoic/arena/GameStateTest.java
@@ -7,6 +7,7 @@ import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Player;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Effect;
+import com.mesozoic.arena.model.SwitchMove;
 import java.util.Random;
 
 import org.junit.jupiter.api.Test;
@@ -87,5 +88,19 @@ public class GameStateTest {
 
         GameState next = state.nextState(brace, strike, new Random(0));
         assertTrue(next.getPlayerOne().getActiveDinosaur().getHealth() < 100);
+    }
+
+    @Test
+    public void testNextStateIgnoresInvalidSwitch() {
+        Dinosaur first = new Dinosaur("Solo", 100, 50,
+                "assets/animals/allosaurus.png", 10, 10, List.of(), null);
+        Player playerOne = new Player(List.of(first));
+        Player playerTwo = new Player(List.of(first.copy()));
+
+        GameState state = new GameState(playerOne, playerTwo);
+        Move invalid = new SwitchMove(first, 1);
+
+        GameState next = state.nextState(invalid, null, new Random(0));
+        assertEquals("Solo", next.getPlayerOne().getActiveDinosaur().getName());
     }
 }


### PR DESCRIPTION
## Summary
- add validity checks when applying SwitchMoves in `GameState.nextState`
- add regression test ensuring invalid switch indices are ignored

## Testing
- `mvn test -DtrimStackTrace=false`

------
https://chatgpt.com/codex/tasks/task_e_687caca9d364832eb9a02ff3d106966e