### PR TITLE
Fix MCTS minimax orientation

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
@@ -97,15 +97,16 @@ public class MCTSNode {
     }
 
     private Move minimaxMove(Random random) {
-        return minimaxMove(state, random);
+        return minimaxMove(state, state.getPlayerOne(), state.getPlayerTwo(), random);
     }
 
-    private Move minimaxMove(GameState currentState, Random random) {
-        List<Move> playerMoves = currentState.availableMovesFor(currentState.getPlayerOne());
+    private Move minimaxMove(GameState currentState, Player maximizingPlayer,
+            Player minimizingPlayer, Random random) {
+        List<Move> playerMoves = currentState.availableMovesFor(maximizingPlayer);
         if (playerMoves.isEmpty()) {
             return null;
         }
-        List<Move> npcMoves = currentState.availableMovesFor(currentState.getPlayerTwo());
+        List<Move> npcMoves = currentState.availableMovesFor(minimizingPlayer);
         if (npcMoves.isEmpty()) {
             return playerMoves.get(random.nextInt(playerMoves.size()));
         }
@@ -133,14 +134,16 @@ public class MCTSNode {
 
     private Move chooseSelfMove(GameState currentState, Random random) {
         if (random.nextDouble() < selfProbability) {
-            return minimaxMove(currentState, random);
+            return minimaxMove(currentState, currentState.getPlayerTwo(),
+                    currentState.getPlayerOne(), random);
         }
         return randomMove(currentState.getPlayerTwo(), random);
     }
 
     private Move chooseOpponentMove(GameState currentState, Random random) {
         if (random.nextDouble() < opponentProbability) {
-            return minimaxMove(currentState, random);
+            return minimaxMove(currentState, currentState.getPlayerOne(),
+                    currentState.getPlayerTwo(), random);
         }
         return randomMove(currentState.getPlayerOne(), random);
     }


### PR DESCRIPTION
## Summary
- ensure the minimax search picks moves for the correct side
- choose self and opponent minimax moves using explicit players

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687cb6425af4832e9a92aae956a280be