### PR TITLE
Disable final epsilon choice and expose MCTS exploration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ When the LLM is disabled the game uses a Monte Carlo Tree Search agent. The
 search depth can be tuned through the `mctsIterations` option in
 `data/constants.ini`. Higher values yield stronger play at the cost of longer
 thinking time. The default is `1000` iterations. The `mctsEpsilon` option
-controls how often the agent explores random moves during search.
+controls how often the agent explores random moves during search. The
+`mctsExploration` option sets the exploration constant used for UCT and
+defaults to `2.0`.
 The `mctsSelfMinimaxProbability` option determines how often the agent
 selects a minimax move during rollouts. Set to `1.0` for purely minimax
 rollouts or `0.0` for random self play. The default is `0.5`.

--- a/data/constants.ini
+++ b/data/constants.ini
@@ -2,5 +2,6 @@
 useLLMAgent=false
 mctsIterations=20000
 mctsEpsilon=0.1
+mctsExploration=2.0
 mctsSelfMinimaxProbability=0.6
 mctsOpponentMinimaxProbability=0.9

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
@@ -117,11 +117,7 @@ public class MCTSAgent implements OpponentAgent {
                 bestChild = child;
             }
         }
-        if (!root.getChildren().isEmpty()
-                && selectionRandom.nextDouble() < epsilon) {
-            bestChild = root.getChildren()
-                    .get(selectionRandom.nextInt(root.getChildren().size()));
-        }
+
 
         if (bestChild == null) {
             List<Move> moves = self.getActiveDinosaur().getMoves();

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
@@ -3,6 +3,7 @@ package com.mesozoic.arena.ai.mcts;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Player;
 import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.util.Config;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -172,7 +173,7 @@ public class MCTSNode {
                 && random.nextDouble() < epsilon) {
             return children.get(random.nextInt(children.size()));
         }
-        double exploration = 2.0;
+        double exploration = Config.mctsExploration();
         MCTSNode best = null;
         double bestValue = Double.NEGATIVE_INFINITY;
         for (MCTSNode child : children) {

--- a/src/main/java/com/mesozoic/arena/util/Config.java
+++ b/src/main/java/com/mesozoic/arena/util/Config.java
@@ -71,6 +71,18 @@ public final class Config {
     }
 
     /**
+     * Returns the exploration constant used by the MCTS agent.
+     */
+    public static double mctsExploration() {
+        String value = properties.getProperty("mctsExploration", "2.0");
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException ignored) {
+            return 2.0;
+        }
+    }
+
+    /**
      * Returns the probability of using a minimax move during rollouts.
      */
     public static double mctsSelfMinimaxProbability() {


### PR DESCRIPTION
## Summary
- remove epsilon-greedy selection for the final move
- allow the MCTS exploration constant to be configured
- document the new option and default value

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687d202e37c4832ea6017fe3d7d89484