### PR TITLE
Improve MCTS rollout evaluation

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSAgent.java
@@ -80,14 +80,14 @@ public class MCTSAgent implements OpponentAgent {
                         //System.out.println("Expansion " + expansionCounter + ": " + expandedMove.getName());
                     }
                 }
-                int result = node.rollout(simulationRandom);
+                double result = node.rollout(simulationRandom);
                 if (expanded && expandedMove != null) {
                     //System.out.println("First rollout result for " + expandedMove.getName() + ": " + result);
                 }
                 node.backpropagate(result);
                 continue;
             }
-            int result = node.rollout(simulationRandom);
+            double result = node.rollout(simulationRandom);
             node.backpropagate(result);
         }
 

--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
@@ -13,6 +13,7 @@ import java.util.Random;
  */
 public class MCTSNode {
     private static final int MAX_ROLLOUT_STEPS = 100;
+    private static final double ADVANTAGE_SCALE = 200.0;
     private final GameState state;
     private final MCTSNode parent;
     private final List<MCTSNode> children = new ArrayList<>();
@@ -94,6 +95,19 @@ public class MCTSNode {
         int p1Health = totalHealth(gameState.getPlayerOne());
         int p2Health = totalHealth(gameState.getPlayerTwo());
         return p1Health - p2Health;
+    }
+
+    private static double evaluateAdvantage(GameState gameState) {
+        int p1Health = totalHealth(gameState.getPlayerOne());
+        int p2Health = totalHealth(gameState.getPlayerTwo());
+        double advantage = (double) (p2Health - p1Health) / ADVANTAGE_SCALE;
+        if (advantage > 0.5) {
+            return 0.5;
+        }
+        if (advantage < -0.5) {
+            return -0.5;
+        }
+        return advantage;
     }
 
     private Move minimaxMove(Random random) {
@@ -192,7 +206,7 @@ public class MCTSNode {
         return bestChild(null, 0.0);
     }
 
-    public int rollout(Random simulationRandom) {
+    public double rollout(Random simulationRandom) {
         GameState current = state;
         int steps = 0;
         while (!current.isTerminal() && steps < MAX_ROLLOUT_STEPS) {
@@ -202,15 +216,18 @@ public class MCTSNode {
             steps++;
         }
         int winner = current.winner();
+        double advantage = evaluateAdvantage(current);
         if (winner == -1) {
-            return 1;
+            double healthBonus = Math.max(0.0, advantage) * 0.5;
+            double stepBonus = 0.25 * (1.0 - steps / (double) MAX_ROLLOUT_STEPS);
+            return 1.0 + healthBonus + stepBonus;
         } else if (winner == 1) {
-            return -1;
+            return -1.0;
         }
-        return 0;
+        return advantage;
     }
 
-    public void backpropagate(int result) {
+    public void backpropagate(double result) {
         MCTSNode node = this;
         while (node != null) {
             node.visitCount++;

--- a/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
@@ -34,7 +34,7 @@ public class MCTSNodeTest {
         Random simulationRandom = new Random(1);
 
         MCTSNode child = root.expand(selectionRandom, simulationRandom);
-        int result = child.rollout(simulationRandom);
+        double result = child.rollout(simulationRandom);
         child.backpropagate(result);
 
         assertEquals(1, child.getVisitCount());
@@ -119,8 +119,8 @@ public class MCTSNodeTest {
         MCTSNode root = new MCTSNode(state, null, null, 0.0, 0.0);
         Random simulationRandom = new Random(0);
 
-        int result = root.rollout(simulationRandom);
-        assertEquals(0, result);
+        double result = root.rollout(simulationRandom);
+        assertEquals(0.0, result);
     }
 
     @Test
@@ -140,7 +140,7 @@ public class MCTSNodeTest {
         MCTSNode root = new MCTSNode(state, null, null, 0.0, 0.0);
         Random simulationRandom = new Random(0);
 
-        int result = root.rollout(simulationRandom);
-        assertEquals(-1, result);
+        double result = root.rollout(simulationRandom);
+        assertEquals(-1.0, result);
     }
 }


### PR DESCRIPTION
## Summary
- tweak rollout reward to account for health advantage and quicker wins
- update MCTS agent to use double scores
- adjust tests for new rollout method

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687d20ee318c832e9339fc08b211da19