### PR TITLE
Update speed tie rule

### DIFF
--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -152,7 +152,19 @@ public class Battle {
         if (p1Priority != p2Priority) {
             p1First = p1Priority > p2Priority;
         } else {
-            p1First = dinoOne.getEffectiveSpeed() >= dinoTwo.getEffectiveSpeed();
+            int p1Speed = dinoOne.getEffectiveSpeed();
+            int p2Speed = dinoTwo.getEffectiveSpeed();
+            if (p1Speed == p2Speed) {
+                int p1Total = playerOne.getTotalHealth();
+                int p2Total = playerTwo.getTotalHealth();
+                if (p1Total == p2Total) {
+                    p1First = true;
+                } else {
+                    p1First = p1Total < p2Total;
+                }
+            } else {
+                p1First = p1Speed > p2Speed;
+            }
         }
 
         boolean p1Braced = false;

--- a/src/main/java/com/mesozoic/arena/model/Player.java
+++ b/src/main/java/com/mesozoic/arena/model/Player.java
@@ -111,4 +111,15 @@ public class Player {
         }
         return clone;
     }
+
+    /**
+     * Returns the sum of the current health of all dinosaurs on the team.
+     */
+    public int getTotalHealth() {
+        int total = 0;
+        for (Dinosaur dinosaur : dinosaurs) {
+            total += dinosaur.getHealth();
+        }
+        return total;
+    }
 }

--- a/src/test/java/com/mesozoic/arena/BattleSpeedTieTest.java
+++ b/src/test/java/com/mesozoic/arena/BattleSpeedTieTest.java
@@ -1,0 +1,51 @@
+package com.mesozoic.arena;
+
+import com.mesozoic.arena.engine.Battle;
+import com.mesozoic.arena.model.Dinosaur;
+import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.Player;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BattleSpeedTieTest {
+
+    @Test
+    public void testLowHealthPlayerActsFirst() {
+        Move strike = new Move("Strike", 10, 0, List.of());
+        Dinosaur weaker = new Dinosaur("Weaker", 50, 10,
+                "assets/animals/allosaurus.png", 1, 1, List.of(strike), null);
+        Dinosaur stronger = new Dinosaur("Stronger", 60, 10,
+                "assets/animals/allosaurus.png", 1, 1, List.of(strike), null);
+        Player p1 = new Player(List.of(weaker));
+        Player p2 = new Player(List.of(stronger));
+        Battle battle = new Battle(p1, p2);
+
+        battle.executeRound(strike, strike);
+
+        List<String> log = battle.getEventLog();
+        assertFalse(log.isEmpty());
+        assertTrue(log.get(0).contains("Player Weaker"));
+    }
+
+    @Test
+    public void testPlayerOneActsFirstWhenHealthEqual() {
+        Move strike = new Move("Strike", 10, 0, List.of());
+        Dinosaur first = new Dinosaur("First", 50, 10,
+                "assets/animals/allosaurus.png", 1, 1, List.of(strike), null);
+        Dinosaur second = new Dinosaur("Second", 50, 10,
+                "assets/animals/allosaurus.png", 1, 1, List.of(strike), null);
+        Player p1 = new Player(List.of(first));
+        Player p2 = new Player(List.of(second));
+        Battle battle = new Battle(p1, p2);
+
+        battle.executeRound(strike, strike);
+
+        List<String> log = battle.getEventLog();
+        assertFalse(log.isEmpty());
+        assertTrue(log.get(0).contains("Player First"));
+    }
+}


### PR DESCRIPTION
## Summary
- break speed ties by comparing total health of each team
- add helper on `Player` to compute total team health
- test new speed tie rule

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_687d3c02af94832e9a6814cf02b7a3a0