### PR TITLE
Add new passive abilities

### DIFF
--- a/data/abilities.yaml
+++ b/data/abilities.yaml
@@ -7,3 +7,5 @@ Armored: Reduces incoming damage by 10.
 Supporter: 0 damage moves gain +1 priority.
 Berserk: Attack increases by one stage after each knockout.
 Tough: Reduces incoming damage threefold when at full health.
+Sharpshooter: Increases move accuracy by 15 percentage points.
+Regenerator: Heals 10 health whenever a move is used.

--- a/src/main/java/com/mesozoic/arena/engine/AbilityEffects.java
+++ b/src/main/java/com/mesozoic/arena/engine/AbilityEffects.java
@@ -118,4 +118,38 @@ public final class AbilityEffects {
             attacker.adjustAttackStage(1);
         }
     }
+
+    /**
+     * Adjusts the accuracy of a move based on the user's ability.
+     *
+     * @param user the dinosaur using the move
+     * @param move the move being used
+     * @return the accuracy after ability modifications
+     */
+    public static double modifyAccuracy(Dinosaur user, Move move) {
+        if (user == null || move == null) {
+            return move == null ? 0.0 : move.getAccuracy();
+        }
+        Ability ability = user.getAbility();
+        if (ability != null && "Sharpshooter".equalsIgnoreCase(ability.getName())) {
+            return Math.min(1.0, move.getAccuracy() + 0.15);
+        }
+        return move.getAccuracy();
+    }
+
+    /**
+     * Triggers effects when the dinosaur performs a move.
+     *
+     * @param user the dinosaur using the move
+     */
+    public static void onMoveUsed(Dinosaur user) {
+        if (user == null) {
+            return;
+        }
+        Ability ability = user.getAbility();
+        if (ability != null && "Regenerator".equalsIgnoreCase(ability.getName())) {
+            int healAmount = AilmentEffects.modifyHealing(user, 10);
+            user.adjustHealth(healAmount);
+        }
+    }
 }

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -33,8 +33,12 @@ public class Battle {
     private int turn = 1;
     private Player winner;
 
-    private boolean moveHits(Move move, Random random) {
-        return move != null && random.nextDouble() < move.getAccuracy();
+    private boolean moveHits(Dinosaur attacker, Move move, Random random) {
+        if (move == null || attacker == null) {
+            return false;
+        }
+        double accuracy = AbilityEffects.modifyAccuracy(attacker, move);
+        return random.nextDouble() < accuracy;
     }
 
     private void logMiss(Player actingPlayer, Dinosaur attacker, Move move) {
@@ -234,6 +238,10 @@ public class Battle {
             boolean defenderBraced, Random random) {
         int repeatCount = MoveEffects.getRepeatCount(move);
         boolean defenderFainted = false;
+        Dinosaur initialAttacker = actingPlayer.getActiveDinosaur();
+        if (move != null && initialAttacker != null) {
+            AbilityEffects.onMoveUsed(initialAttacker);
+        }
         for (int index = 0; index < repeatCount; index++) {
             Dinosaur attacker = actingPlayer.getActiveDinosaur();
             Dinosaur defender = opposingPlayer.getActiveDinosaur();
@@ -241,7 +249,7 @@ public class Battle {
                 return defenderFainted;
             }
 
-            if (!moveHits(move, random)) {
+            if (!moveHits(attacker, move, random)) {
                 logMiss(actingPlayer, attacker, move);
                 defenderBraced = false;
                 continue;

--- a/src/test/java/com/mesozoic/arena/AbilityEffectsTest.java
+++ b/src/test/java/com/mesozoic/arena/AbilityEffectsTest.java
@@ -4,6 +4,10 @@ import com.mesozoic.arena.model.Ability;
 import com.mesozoic.arena.model.Player;
 import com.mesozoic.arena.engine.Battle;
 import com.mesozoic.arena.engine.AbilityEffects;
+import com.mesozoic.arena.model.MoveType;
+import com.mesozoic.arena.model.DinoType;
+
+import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -160,6 +164,53 @@ public class AbilityEffectsTest {
 
         assertEquals(intimidator, p1.getActiveDinosaur());
         assertEquals(-1, attacker.getAttackStage());
+    }
+
+    @Test
+    public void testSharpshooterBoostsAccuracy() {
+        Move lowAcc = new Move("LowAcc", 10, 0, "", MoveType.BODY,
+                DinoType.BITER, List.of(), 0.8);
+        Move waitMove = new Move("Wait", 0, 0, List.of());
+
+        Dinosaur sharpshooter = new Dinosaur("Sharp", 100, 50,
+                "assets/animals/allosaurus.png", 1, 1, List.of(lowAcc),
+                new Ability("Sharpshooter", ""));
+        Dinosaur target = new Dinosaur("Target", 100, 50,
+                "assets/animals/allosaurus.png", 1, 1, List.of(waitMove), null);
+
+        Player p1 = new Player(List.of(sharpshooter));
+        Player p2 = new Player(List.of(target));
+        Battle battle = new Battle(p1, p2);
+
+        Random rng = new Random() {
+            @Override
+            public double nextDouble() {
+                return 0.9; // would miss without ability
+            }
+        };
+
+        battle.executeRound(lowAcc, waitMove, rng);
+
+        assertEquals(92, target.getHealth());
+    }
+
+    @Test
+    public void testRegeneratorHealsOnMoveUse() {
+        Move waitMove = new Move("Wait", 0, 0, List.of());
+        Dinosaur healer = new Dinosaur("Healer", 100, 50,
+                "assets/animals/allosaurus.png", 1, 1, List.of(waitMove),
+                new Ability("Regenerator", ""));
+        Dinosaur target = new Dinosaur("Target", 100, 50,
+                "assets/animals/allosaurus.png", 1, 1, List.of(waitMove), null);
+
+        Player p1 = new Player(List.of(healer));
+        Player p2 = new Player(List.of(target));
+        Battle battle = new Battle(p1, p2);
+
+        healer.adjustHealth(-20);
+        battle.executeRound(waitMove, waitMove, new Random(0));
+
+        assertEquals(90, healer.getHealth());
     }
 }
 


### PR DESCRIPTION
## Summary
- add `Sharpshooter` and `Regenerator` ability descriptions
- let abilities adjust accuracy and heal when a move is used
- support accuracy bonus and healing in the battle engine
- test the new abilities

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687d7ac13120832e867d544653e3ae31