### PR TITLE
Improve MCTS loss evaluation

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/MCTSNode.java
@@ -214,7 +214,8 @@ public class MCTSNode {
             double stepBonus = 0.25 * (1.0 - steps / (double) MAX_ROLLOUT_STEPS);
             return 1.0 + healthBonus + stepBonus;
         } else if (winner == 1) {
-            return -1.0;
+            double healthPenalty = Math.max(0.0, -advantage) * 0.5;
+            return -1.0 - healthPenalty;
         }
         return advantage;
     }

--- a/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
+++ b/src/test/java/com/mesozoic/arena/MCTSNodeTest.java
@@ -141,6 +141,6 @@ public class MCTSNodeTest {
         Random simulationRandom = new Random(0);
 
         double result = root.rollout(simulationRandom);
-        assertEquals(-1.0, result);
+        assertEquals(-1.05, result);
     }
 }


### PR DESCRIPTION
## Summary
- modify MCTS rollout to scale negative rewards by remaining HP
- update expectation in MCTS test for brace history

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687e5dec6834832e87c0e3d8442a94c7