### PR TITLE
Implement drain move effects

### DIFF
--- a/data/effects.yaml
+++ b/data/effects.yaml
@@ -9,3 +9,5 @@ slow: Reduces the opponent's speed by one stage.
 switch out: After attacking, immediately switch to the next dinosaur.
 fatigue: Lowers your attack by one stage after use.
 recoil: Deals 25% of the damage dealt back to the user.
+big drain: Heals the user for 50% of the damage dealt.
+small drain: Heals the user for 25% of the damage dealt.

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -266,6 +266,7 @@ public class Battle {
                     int recoil = damageDealt / 4;
                     attacker.adjustHealth(-recoil);
                 }
+                MoveEffects.applyDrain(attacker, move, damageDealt);
                 String actorLabel = actingPlayer == playerOne ? "Player " : "NPC ";
                 String defenderLabel = opposingPlayer == playerOne ? "Player " : "NPC ";
                 addEvent(actorLabel + attacker.getName() + " used " + move.getName() +

--- a/src/main/java/com/mesozoic/arena/engine/MoveEffects.java
+++ b/src/main/java/com/mesozoic/arena/engine/MoveEffects.java
@@ -2,6 +2,7 @@ package com.mesozoic.arena.engine;
 
 import com.mesozoic.arena.model.Effect;
 import com.mesozoic.arena.model.Move;
+import com.mesozoic.arena.model.Dinosaur;
 
 /**
  * Utility functions for processing move based effects.
@@ -55,5 +56,31 @@ public final class MoveEffects {
             return 2;
         }
         return 1;
+    }
+
+    /**
+     * Applies drain healing based on the damage dealt and move effects.
+     * Heals half the damage for big drain or a quarter for small drain.
+     *
+     * @param user        the dinosaur using the move
+     * @param move        the move being used
+     * @param damageDealt the damage inflicted on the opponent
+     */
+    public static void applyDrain(Dinosaur user, Move move, int damageDealt) {
+        if (user == null || move == null || damageDealt <= 0) {
+            return;
+        }
+        int percent = 0;
+        if (containsEffect(move, "big drain")) {
+            percent = 50;
+        } else if (containsEffect(move, "small drain")) {
+            percent = 25;
+        }
+        if (percent == 0) {
+            return;
+        }
+        int healAmount = damageDealt * percent / 100;
+        healAmount = AilmentEffects.modifyHealing(user, healAmount);
+        user.adjustHealth(healAmount);
     }
 }

--- a/src/test/java/com/mesozoic/arena/MoveEffectsTest.java
+++ b/src/test/java/com/mesozoic/arena/MoveEffectsTest.java
@@ -5,6 +5,8 @@ import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Effect;
 import com.mesozoic.arena.model.Player;
 import com.mesozoic.arena.engine.Battle;
+import com.mesozoic.arena.model.MoveType;
+import com.mesozoic.arena.model.DinoType;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -194,5 +196,45 @@ public class MoveEffectsTest {
 
         battle.executeRound(recoil, noop);
         assertEquals(97, attacker.getHealth());
+    }
+
+    @Test
+    public void testBigDrainHealsHalfDamage() {
+        Move drain = new Move("Drain", 20, 0, "", MoveType.HEAD, DinoType.RUNNER,
+                List.of(new Effect("big drain")), 1.0);
+        Move noop = new Move("Wait", 0, 0, List.of());
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 1, 1,
+                List.of(drain), null, List.of(DinoType.CHARGER));
+        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 1, 1,
+                List.of(noop), null);
+        Player p1 = new Player(List.of(attacker));
+        Player p2 = new Player(List.of(defender));
+        Battle battle = new Battle(p1, p2);
+
+        attacker.adjustHealth(-40);
+        battle.executeRound(drain, noop);
+
+        assertEquals(70, attacker.getHealth());
+        assertEquals(80, defender.getHealth());
+    }
+
+    @Test
+    public void testSmallDrainHealsQuarterDamage() {
+        Move drain = new Move("Nibble", 20, 0, "", MoveType.HEAD, DinoType.RUNNER,
+                List.of(new Effect("small drain")), 1.0);
+        Move noop = new Move("Wait", 0, 0, List.of());
+        Dinosaur attacker = new Dinosaur("Attacker", 100, 50, "assets/animals/allosaurus.png", 1, 1,
+                List.of(drain), null, List.of(DinoType.CHARGER));
+        Dinosaur defender = new Dinosaur("Defender", 100, 50, "assets/animals/allosaurus.png", 1, 1,
+                List.of(noop), null);
+        Player p1 = new Player(List.of(attacker));
+        Player p2 = new Player(List.of(defender));
+        Battle battle = new Battle(p1, p2);
+
+        attacker.adjustHealth(-40);
+        battle.executeRound(drain, noop);
+
+        assertEquals(65, attacker.getHealth());
+        assertEquals(80, defender.getHealth());
     }
 }


### PR DESCRIPTION
## Summary
- add `applyDrain` utility for big/small drain
- apply drain healing when resolving damage in battles
- document drain effects in `effects.yaml`
- test big and small drain mechanics

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687ffdfd6f9c832ead15b7f6fecf0a18