### PR TITLE
Add menu bar with settings dialog

### DIFF
--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -3,6 +3,7 @@ package com.mesozoic.arena.ui;
 import com.mesozoic.arena.engine.Battle;
 import com.mesozoic.arena.model.*;
 import com.mesozoic.arena.engine.DamageCalculator;
+import com.mesozoic.arena.util.Config;
 
 import javax.swing.*;
 import java.awt.*;
@@ -42,6 +43,7 @@ public class MainWindow extends JFrame {
 
         setDefaultCloseOperation(EXIT_ON_CLOSE);
         setSize(1850, 950);
+        setupMenuBar();
 
         playerPanel   = new DinoPanel(true);
         opponentPanel = new DinoPanel(false);
@@ -82,6 +84,55 @@ public class MainWindow extends JFrame {
         updateDinoPanel(opponentPanel, opponent);
         logArea.setText(String.join("\n", battle.getEventLog()));
         npcArea.setText(String.join("\n", battle.getAiLog()));
+    }
+
+    private void setupMenuBar() {
+        JMenuBar bar = new JMenuBar();
+        JMenu file = new JMenu("File");
+
+        JMenuItem settings = new JMenuItem("Settings");
+        settings.addActionListener(e -> openSettingsDialog());
+        JMenuItem exit = new JMenuItem("Exit");
+        exit.addActionListener(e -> System.exit(0));
+
+        file.add(settings);
+        file.add(exit);
+        bar.add(file);
+        setJMenuBar(bar);
+    }
+
+    private void openSettingsDialog() {
+        JDialog dialog = new JDialog(this, "Settings", true);
+        JLabel label = new JLabel("Supply Budget:");
+        JTextField budgetField = new JTextField(String.valueOf(Config.supplyBudget()), 10);
+
+        JButton save = new JButton("Save");
+        JButton cancel = new JButton("Cancel");
+
+        save.addActionListener(ev -> {
+            try {
+                int value = Integer.parseInt(budgetField.getText().trim());
+                Config.setSupplyBudget(value);
+                dialog.dispose();
+            } catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(dialog, "Invalid number", "Error", JOptionPane.ERROR_MESSAGE);
+            }
+        });
+        cancel.addActionListener(ev -> dialog.dispose());
+
+        JPanel fields = new JPanel(new FlowLayout());
+        fields.add(label);
+        fields.add(budgetField);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        buttons.add(save);
+        buttons.add(cancel);
+
+        dialog.getContentPane().add(fields, BorderLayout.CENTER);
+        dialog.getContentPane().add(buttons, BorderLayout.SOUTH);
+        dialog.pack();
+        dialog.setLocationRelativeTo(this);
+        dialog.setVisible(true);
     }
 
     private void updateDinoPanel(DinoPanel panel, Player who) {

--- a/src/main/java/com/mesozoic/arena/util/Config.java
+++ b/src/main/java/com/mesozoic/arena/util/Config.java
@@ -14,6 +14,8 @@ public final class Config {
     private static final String GEMINI_ENV_FILE = "gemini.env";
     private static final Properties properties = new Properties();
     private static final Properties secrets = new Properties();
+    private static final java.nio.file.Path CONFIG_PATH =
+            java.nio.file.Path.of("data", CONFIG_FILE);
 
     static {
         loadProperties(CONFIG_FILE, properties);
@@ -32,6 +34,13 @@ public final class Config {
 
         try (InputStream in = Files.newInputStream(Path.of(fileName))) {
             target.load(in);
+        } catch (IOException ignored) {
+        }
+    }
+
+    private static void saveProperties() {
+        try (java.io.OutputStream out = java.nio.file.Files.newOutputStream(CONFIG_PATH)) {
+            properties.store(out, null);
         } catch (IOException ignored) {
         }
     }
@@ -116,6 +125,14 @@ public final class Config {
         } catch (NumberFormatException ignored) {
             return 30;
         }
+    }
+
+    /**
+     * Updates the supply budget in memory and writes it to {@code data/constants.ini}.
+     */
+    public static void setSupplyBudget(int budget) {
+        properties.setProperty("supplyBudget", Integer.toString(budget));
+        saveProperties();
     }
 
 


### PR DESCRIPTION
## Summary
- add Config.CONFIG_PATH and methods to persist properties
- expose Config.setSupplyBudget for changing the supply budget
- add menu bar with File > Settings and Exit
- implement settings dialog to edit supply budget

## Testing
- `mvn -q test` *(fails: AbilityEffectsTest.testScavengerHealsOnKnockOut expected 80 but was 60)*

------
https://chatgpt.com/codex/tasks/task_e_6882b4726780832e871780c58aa2d72b