### PR TITLE
Add persistent effects system

### DIFF
--- a/data/persistent_effects.yaml
+++ b/data/persistent_effects.yaml
@@ -1,0 +1,6 @@
+Tailwind:
+  description: Increases the active dinosaur's speed by 50%.
+  duration: 5
+Rocks:
+  description: Damages incoming dinosaurs by 12.5% of their max HP.
+  duration: 0

--- a/src/main/java/com/mesozoic/arena/model/PersistentEffect.java
+++ b/src/main/java/com/mesozoic/arena/model/PersistentEffect.java
@@ -1,0 +1,43 @@
+package com.mesozoic.arena.model;
+
+/**
+ * Active instance of a persistent effect on a team.
+ */
+public class PersistentEffect {
+    private final PersistentEffectDefinition definition;
+    private int remaining;
+
+    public PersistentEffect(PersistentEffectDefinition definition) {
+        this.definition = definition;
+        this.remaining = definition.getDuration();
+    }
+
+    public String getName() {
+        return definition.getName();
+    }
+
+    public String getDescription() {
+        return definition.getDescription();
+    }
+
+    public int getDuration() {
+        return definition.getDuration();
+    }
+
+    public int getRemaining() {
+        return remaining;
+    }
+
+    public void tick() {
+        if (definition.getDuration() <= 0) {
+            return;
+        }
+        if (remaining > 0) {
+            remaining--;
+        }
+    }
+
+    public boolean isExpired() {
+        return definition.getDuration() > 0 && remaining <= 0;
+    }
+}

--- a/src/main/java/com/mesozoic/arena/model/PersistentEffectDefinition.java
+++ b/src/main/java/com/mesozoic/arena/model/PersistentEffectDefinition.java
@@ -1,0 +1,28 @@
+package com.mesozoic.arena.model;
+
+/**
+ * Defines a persistent effect loaded from configuration.
+ */
+public class PersistentEffectDefinition {
+    private final String name;
+    private final String description;
+    private final int duration;
+
+    public PersistentEffectDefinition(String name, String description, int duration) {
+        this.name = name;
+        this.description = description == null ? "" : description;
+        this.duration = duration;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+}

--- a/src/main/java/com/mesozoic/arena/ui/MainWindow.java
+++ b/src/main/java/com/mesozoic/arena/ui/MainWindow.java
@@ -180,6 +180,29 @@ public class MainWindow extends JFrame {
 
         panel.teamSupply.setText("Team Supply: " + who.getTotalSupply());
         panel.teamHealth.setText("Total HP: " + who.getTotalHealth());
+        java.util.List<com.mesozoic.arena.model.PersistentEffect> effectsList =
+                who.getPersistentEffects();
+        if (effectsList.isEmpty()) {
+            panel.effectsHeading.setVisible(false);
+            panel.effects.setText("");
+        } else {
+            panel.effectsHeading.setVisible(true);
+            StringBuilder eff = new StringBuilder();
+            for (int i = 0; i < effectsList.size(); i++) {
+                com.mesozoic.arena.model.PersistentEffect pe = effectsList.get(i);
+                if (i > 0) {
+                    eff.append(", ");
+                }
+                eff.append(pe.getName());
+                int remain = pe.getDuration() <= 0 ? -1 : pe.getRemaining();
+                if (remain < 0) {
+                    eff.append(" (∞)");
+                } else {
+                    eff.append(" (").append(remain).append(")");
+                }
+            }
+            panel.effects.setText(eff.toString());
+        }
 
         panel.bench.removeAll();
         for (Dinosaur dd : who.getDinosaurs()) {
@@ -461,6 +484,8 @@ public class MainWindow extends JFrame {
         final JLabel teamHeading = new JLabel("Team Stats");
         final JLabel teamSupply  = new JLabel();
         final JLabel teamHealth  = new JLabel();
+        final JLabel effectsHeading = new JLabel("Effects:");
+        final JLabel effects      = new JLabel();
         final JPanel bench   = new JPanel(new FlowLayout(FlowLayout.LEFT, 5,5));
         final JPanel moves   = new JPanel(new GridLayout(0,2,5,5));
 
@@ -477,9 +502,13 @@ public class MainWindow extends JFrame {
             teamSupply.setFont(teamSupply.getFont().deriveFont(Font.BOLD, 14f));
             teamHealth.setAlignmentX(Component.CENTER_ALIGNMENT);
             teamHealth.setFont(teamHealth.getFont().deriveFont(Font.BOLD, 14f));
+            effectsHeading.setAlignmentX(Component.CENTER_ALIGNMENT);
+            effects.setAlignmentX(Component.CENTER_ALIGNMENT);
             statsBox.add(teamHeading);
             statsBox.add(teamSupply);
             statsBox.add(teamHealth);
+            statsBox.add(effectsHeading);
+            statsBox.add(effects);
 
             JPanel top = new JPanel(new BorderLayout());
             if (isPlayer) {

--- a/src/main/java/com/mesozoic/arena/util/PersistentEffectLoader.java
+++ b/src/main/java/com/mesozoic/arena/util/PersistentEffectLoader.java
@@ -1,0 +1,68 @@
+package com.mesozoic.arena.util;
+
+import com.mesozoic.arena.model.PersistentEffectDefinition;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Loads persistent effect definitions from {@code persistent_effects.yaml}.
+ */
+public final class PersistentEffectLoader {
+    private static final String EFFECT_FILE = "data/persistent_effects.yaml";
+
+    private PersistentEffectLoader() {
+    }
+
+    /**
+     * Returns a map of effect names to their definitions.
+     */
+    public static Map<String, PersistentEffectDefinition> loadDefinitions() {
+        Map<String, PersistentEffectDefinition> map = new HashMap<>();
+        Yaml yaml = new Yaml();
+
+        try (InputStream input = PersistentEffectLoader.class.getClassLoader()
+                .getResourceAsStream("persistent_effects.yaml")) {
+            if (input != null) {
+                Map<String, Object> root = yaml.load(input);
+                copyEntries(root, map);
+                return map;
+            }
+        } catch (IOException ignored) {
+        }
+
+        try (InputStream input = Files.newInputStream(Path.of(EFFECT_FILE))) {
+            Map<String, Object> root = yaml.load(input);
+            copyEntries(root, map);
+        } catch (IOException ignored) {
+        }
+        return map;
+    }
+
+    private static void copyEntries(Map<String, Object> source,
+            Map<String, PersistentEffectDefinition> target) {
+        if (source == null) {
+            return;
+        }
+        for (Entry<String, Object> entry : source.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            if (entry.getValue() instanceof Map<?,?> values) {
+                String name = entry.getKey();
+                Object descRaw = values.get("description");
+                Object durRaw = values.get("duration");
+                String description = descRaw == null ? "" : String.valueOf(descRaw);
+                int duration = durRaw == null ? 0
+                        : ((Number) durRaw).intValue();
+                target.put(name,
+                        new PersistentEffectDefinition(name, description, duration));
+            }
+        }
+    }
+}

--- a/src/main/java/com/mesozoic/arena/util/PersistentEffectRegistry.java
+++ b/src/main/java/com/mesozoic/arena/util/PersistentEffectRegistry.java
@@ -1,0 +1,25 @@
+package com.mesozoic.arena.util;
+
+import com.mesozoic.arena.model.PersistentEffect;
+import com.mesozoic.arena.model.PersistentEffectDefinition;
+import java.util.Map;
+
+/**
+ * Provides access to persistent effect definitions.
+ */
+public final class PersistentEffectRegistry {
+    private static final Map<String, PersistentEffectDefinition> DEFINITIONS =
+            PersistentEffectLoader.loadDefinitions();
+
+    private PersistentEffectRegistry() {
+    }
+
+    public static PersistentEffectDefinition getDefinition(String name) {
+        return DEFINITIONS.get(name);
+    }
+
+    public static PersistentEffect createEffect(String name) {
+        PersistentEffectDefinition def = DEFINITIONS.get(name);
+        return def == null ? null : new PersistentEffect(def);
+    }
+}

--- a/src/test/java/com/mesozoic/arena/PersistentEffectBattleTest.java
+++ b/src/test/java/com/mesozoic/arena/PersistentEffectBattleTest.java
@@ -1,0 +1,36 @@
+package com.mesozoic.arena;
+
+import com.mesozoic.arena.engine.Battle;
+import com.mesozoic.arena.model.*;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PersistentEffectBattleTest {
+    @Test
+    public void testTailwindAndRocksMechanics() {
+        Move tailwind = new Move("Tailwind", 0, 0,
+                List.of(new Effect("tailwind")));
+        Move rocks = new Move("Rocks", 0, 0,
+                List.of(new Effect("rocks")));
+        Dinosaur a1 = new Dinosaur("A1", 100, 100, "", 1, 1,
+                List.of(tailwind), null);
+        Dinosaur a2 = new Dinosaur("A2", 80, 50, "", 1, 1,
+                List.of(), null);
+        Player p1 = new Player(List.of(a1, a2));
+        Dinosaur b1 = new Dinosaur("B1", 100, 80, "", 1, 1,
+                List.of(rocks), null);
+        Player p2 = new Player(List.of(b1));
+
+        Battle battle = new Battle(p1, p2);
+        battle.executeRound(tailwind, rocks);
+
+        assertTrue(p1.hasPersistentEffect("Tailwind"));
+        assertEquals(4, p1.getPersistentEffects().get(0).getRemaining());
+
+        p1.queueSwitch(a2);
+        battle.executeRound(null, null);
+        int expected = Math.round(a2.getMaxHealth() * 0.125f);
+        assertEquals(a2.getMaxHealth() - expected, a2.getHealth());
+    }
+}

--- a/src/test/java/com/mesozoic/arena/PersistentEffectLoaderTest.java
+++ b/src/test/java/com/mesozoic/arena/PersistentEffectLoaderTest.java
@@ -1,0 +1,18 @@
+package com.mesozoic.arena;
+
+import com.mesozoic.arena.util.PersistentEffectLoader;
+import com.mesozoic.arena.model.PersistentEffectDefinition;
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PersistentEffectLoaderTest {
+    @Test
+    public void testLoadDefinitions() {
+        Map<String, PersistentEffectDefinition> defs =
+                PersistentEffectLoader.loadDefinitions();
+        assertTrue(defs.containsKey("Tailwind"));
+        assertEquals(5, defs.get("Tailwind").getDuration());
+        assertTrue(defs.containsKey("Rocks"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement persistent effect model with YAML definitions
- update `Player` and `Battle` to handle persistent effects
- show active persistent effects in the UI
- include new YAML file describing Tailwind and Rocks
- add unit tests for persistent effects

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6882bd6400ac832ebef4371a5ec81fc3