### PR TITLE
Fix MCTS persistent effects handling

### DIFF
--- a/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
+++ b/src/main/java/com/mesozoic/arena/ai/mcts/GameState.java
@@ -44,10 +44,7 @@ public class GameState {
         this.playerOne = playerOne;
         this.playerTwo = playerTwo;
         this.history = history == null ? new ArrayList<>() : new ArrayList<>(history);
-        this.battle = new Battle(this.playerOne, this.playerTwo, this.history);
-        if (!applyEntry) {
-            revertEntryEffects();
-        }
+        this.battle = new Battle(this.playerOne, this.playerTwo, this.history, applyEntry);
     }
 
     public Player getPlayerOne() {
@@ -122,18 +119,5 @@ public class GameState {
         return battle.getWinner() == playerOne ? 1 : -1;
     }
 
-    private void revertEntryEffects() {
-        Dinosaur activeOne = playerOne.getActiveDinosaur();
-        Dinosaur activeTwo = playerTwo.getActiveDinosaur();
-        if (activeOne != null && activeOne.getAbility() != null
-                && "Intimidate".equalsIgnoreCase(activeOne.getAbility().getName())
-                && activeTwo != null) {
-            activeTwo.adjustHeadAttackStage(1);
-        }
-        if (activeTwo != null && activeTwo.getAbility() != null
-                && "Intimidate".equalsIgnoreCase(activeTwo.getAbility().getName())
-                && activeOne != null) {
-            activeOne.adjustHeadAttackStage(1);
-        }
-    }
+
 }

--- a/src/main/java/com/mesozoic/arena/engine/Battle.java
+++ b/src/main/java/com/mesozoic/arena/engine/Battle.java
@@ -51,24 +51,34 @@ public class Battle {
     }
 
     public Battle(Player playerOne, Player playerTwo) {
-        this(playerOne, playerTwo, createAgent(), new ArrayList<>());
+        this(playerOne, playerTwo, createAgent(), new ArrayList<>(), true);
     }
 
     public Battle(Player playerOne, Player playerTwo, OpponentAgent opponentAI) {
-        this(playerOne, playerTwo, opponentAI, new ArrayList<>());
+        this(playerOne, playerTwo, opponentAI, new ArrayList<>(), true);
     }
 
     public Battle(Player playerOne, Player playerTwo, List<TurnRecord> history) {
-        this(playerOne, playerTwo, createAgent(), history);
+        this(playerOne, playerTwo, createAgent(), history, true);
     }
 
     public Battle(Player playerOne, Player playerTwo, OpponentAgent opponentAI, List<TurnRecord> history) {
+        this(playerOne, playerTwo, opponentAI, history, true);
+    }
+
+    public Battle(Player playerOne, Player playerTwo, List<TurnRecord> history, boolean applyEntry) {
+        this(playerOne, playerTwo, createAgent(), history, applyEntry);
+    }
+
+    public Battle(Player playerOne, Player playerTwo, OpponentAgent opponentAI, List<TurnRecord> history, boolean applyEntry) {
         this.playerOne = playerOne;
         this.playerTwo = playerTwo;
         this.opponentAI = opponentAI;
         this.moveHistory = history == null ? new ArrayList<>() : history;
-        handleEntry(playerOne, playerTwo);
-        handleEntry(playerTwo, playerOne);
+        if (applyEntry) {
+            handleEntry(playerOne, playerTwo);
+            handleEntry(playerTwo, playerOne);
+        }
     }
 
     /**

--- a/src/main/java/com/mesozoic/arena/model/PersistentEffect.java
+++ b/src/main/java/com/mesozoic/arena/model/PersistentEffect.java
@@ -12,6 +12,15 @@ public class PersistentEffect {
         this.remaining = definition.getDuration();
     }
 
+    public PersistentEffect(PersistentEffect other) {
+        this.definition = other.definition;
+        this.remaining = other.remaining;
+    }
+
+    public PersistentEffect copy() {
+        return new PersistentEffect(this);
+    }
+
     public String getName() {
         return definition.getName();
     }

--- a/src/main/java/com/mesozoic/arena/model/Player.java
+++ b/src/main/java/com/mesozoic/arena/model/Player.java
@@ -114,10 +114,7 @@ public class Player {
             }
         }
         for (PersistentEffect effect : persistentEffects) {
-            clone.persistentEffects.add(
-                    new PersistentEffect(new PersistentEffectDefinition(
-                            effect.getName(), effect.getDescription(),
-                            effect.getDuration())));
+            clone.persistentEffects.add(effect.copy());
         }
         return clone;
     }

--- a/src/test/java/com/mesozoic/arena/GameStateTest.java
+++ b/src/test/java/com/mesozoic/arena/GameStateTest.java
@@ -7,6 +7,7 @@ import com.mesozoic.arena.model.Dinosaur;
 import com.mesozoic.arena.model.Player;
 import com.mesozoic.arena.model.Move;
 import com.mesozoic.arena.model.Effect;
+import com.mesozoic.arena.util.PersistentEffectRegistry;
 import java.util.Random;
 
 import org.junit.jupiter.api.Test;
@@ -87,5 +88,34 @@ public class GameStateTest {
 
         GameState next = state.nextState(brace, strike, new Random(0));
         assertTrue(next.getPlayerOne().getActiveDinosaur().getHealth() < 100);
+    }
+
+    @Test
+    public void testPersistentEffectDurationPreserved() {
+        Dinosaur dino = new Dinosaur("A", 100, 50, "", 1, 1, List.of(), null);
+        Player p1 = new Player(List.of(dino));
+        p1.addPersistentEffect(PersistentEffectRegistry.createEffect("Tailwind"));
+        p1.tickPersistentEffects();
+        int remaining = p1.getPersistentEffects().get(0).getRemaining();
+
+        Player p2 = new Player(List.of(dino.copy()));
+        GameState state = new GameState(p1, p2);
+        int copied = state.getPlayerOne().getPersistentEffects().get(0).getRemaining();
+        assertEquals(remaining, copied);
+    }
+
+    @Test
+    public void testHazardDamageNotRepeated() {
+        Dinosaur a = new Dinosaur("A", 100, 50, "", 1, 1, List.of(), null);
+        Player p1 = new Player(List.of(a));
+        p1.addPersistentEffect(PersistentEffectRegistry.createEffect("Rocks"));
+        Dinosaur b = new Dinosaur("B", 100, 50, "", 1, 1, List.of(), null);
+        Player p2 = new Player(List.of(b));
+        Battle battle = new Battle(p1, p2);
+        int healthAfterEntry = p1.getActiveDinosaur().getHealth();
+
+        GameState state = new GameState(p1, p2);
+        int healthInState = state.getPlayerOne().getActiveDinosaur().getHealth();
+        assertEquals(healthAfterEntry, healthInState);
     }
 }


### PR DESCRIPTION
## Summary
- preserve remaining duration when copying persistent effects
- allow creating Battle instances without triggering entry effects
- keep GameState from reapplying entry effects when cloning
- test persistent effect duration and hazard damage in game state

## Testing
- `mvn test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_6883d08815bc832e99efd425751e8d9f